### PR TITLE
Sync outbound queue

### DIFF
--- a/wisely/assets/sqlite/create_outbound_db.sql
+++ b/wisely/assets/sqlite/create_outbound_db.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "outbound" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  "created_at" INTEGER NOT NULL,
+  "status" INTEGER NOT NULL,
+  "updated_at" INTEGER,
+  "message" TEXT NOT NULL,
+  "subject" TEXT NOT NULL
+);

--- a/wisely/assets/sqlite/create_outbound_db.sql
+++ b/wisely/assets/sqlite/create_outbound_db.sql
@@ -2,6 +2,7 @@ CREATE TABLE "outbound" (
   "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "created_at" INTEGER NOT NULL,
   "status" INTEGER NOT NULL,
+  "retries" INTEGER NOT NULL,
   "updated_at" INTEGER,
   "message" TEXT NOT NULL,
   "encrypted_file_path" TEXT,

--- a/wisely/assets/sqlite/create_outbound_db.sql
+++ b/wisely/assets/sqlite/create_outbound_db.sql
@@ -4,5 +4,6 @@ CREATE TABLE "outbound" (
   "status" INTEGER NOT NULL,
   "updated_at" INTEGER,
   "message" TEXT NOT NULL,
+  "encrypted_file_path" TEXT,
   "subject" TEXT NOT NULL
 );

--- a/wisely/lib/blocs/audio/recorder_cubit.dart
+++ b/wisely/lib/blocs/audio/recorder_cubit.dart
@@ -88,7 +88,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
       await AudioUtils.saveAudioNoteJson(_audioNote!);
       File? audioFile = await AudioUtils.getAudioFile(_audioNote!);
 
-      await _outboundQueueCubit.enqueueSyncMessage(
+      await _outboundQueueCubit.enqueueMessage(
         SyncMessage.journalEntity(
           journalEntity: _audioNote!,
           vectorClock: next,

--- a/wisely/lib/blocs/journal/journal_cubit.dart
+++ b/wisely/lib/blocs/journal/journal_cubit.dart
@@ -7,7 +7,7 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 import 'package:wisely/blocs/journal_entities_cubit.dart';
-import 'package:wisely/blocs/sync/imap_cubit.dart';
+import 'package:wisely/blocs/sync/outbound_queue_cubit.dart';
 import 'package:wisely/blocs/sync/vector_clock_cubit.dart';
 import 'package:wisely/classes/geolocation.dart';
 import 'package:wisely/classes/journal_entities.dart';
@@ -20,19 +20,19 @@ import 'package:wisely/utils/image_utils.dart';
 import 'journal_state.dart';
 
 class JournalCubit extends Cubit<JournalState> {
-  late final ImapCubit _imapCubit;
   late final VectorClockCubit _vectorClockCubit;
   late final JournalEntitiesCubit _journalEntitiesCubit;
+  late final OutboundQueueCubit _outboundQueueCubit;
 
   JournalCubit({
-    required ImapCubit imapCubit,
     required VectorClockCubit vectorClockCubit,
     required JournalEntitiesCubit journalEntitiesCubit,
+    required OutboundQueueCubit outboundQueueCubit,
   }) : super(JournalState()) {
     print('Hello from JournalCubit');
-    _imapCubit = imapCubit;
     _vectorClockCubit = vectorClockCubit;
     _journalEntitiesCubit = journalEntitiesCubit;
+    _outboundQueueCubit = outboundQueueCubit;
   }
 
   Future<void> pickImageAssets(BuildContext context) async {
@@ -112,7 +112,7 @@ class JournalCubit extends Cubit<JournalState> {
           await saveJournalImageJson(journalImage);
           _journalEntitiesCubit.save(journalImage);
 
-          await _imapCubit.saveEncryptedImap(
+          await _outboundQueueCubit.enqueueSyncMessage(
             SyncMessage.journalEntity(
               journalEntity: journalImage,
               vectorClock: vectorClock,

--- a/wisely/lib/blocs/journal/journal_cubit.dart
+++ b/wisely/lib/blocs/journal/journal_cubit.dart
@@ -112,7 +112,7 @@ class JournalCubit extends Cubit<JournalState> {
           await saveJournalImageJson(journalImage);
           _journalEntitiesCubit.save(journalImage);
 
-          await _outboundQueueCubit.enqueueSyncMessage(
+          await _outboundQueueCubit.enqueueMessage(
             SyncMessage.journalEntity(
               journalEntity: journalImage,
               vectorClock: vectorClock,

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
@@ -15,8 +14,6 @@ import 'package:wisely/blocs/sync/encryption_cubit.dart';
 import 'package:wisely/blocs/sync/imap_state.dart';
 import 'package:wisely/classes/journal_entities.dart';
 import 'package:wisely/classes/sync_message.dart';
-import 'package:wisely/sync/encryption.dart';
-import 'package:wisely/sync/encryption_salsa.dart';
 
 import '../journal_entities_cubit.dart';
 import 'imap_tools.dart';
@@ -142,20 +139,16 @@ class ImapCubit extends Cubit<ImapState> {
     }
   }
 
-  Future<void> saveEncryptedImap(
-    SyncMessage syncMessage, {
-    File? attachment,
+  Future<void> saveImap(
+    String encryptedMessage,
+    String subject, {
+    String? encryptedFilePath,
   }) async {
-    String jsonString = json.encode(syncMessage);
-    String subject = syncMessage.vectorClock.toString();
-
     if (_b64Secret != null) {
-      String encryptedMessage = encryptSalsa(jsonString, _b64Secret);
-      if (attachment != null) {
-        int fileLength = attachment.lengthSync();
+      if (encryptedFilePath != null) {
+        File encryptedFile = File(encryptedFilePath);
+        int fileLength = encryptedFile.lengthSync();
         if (fileLength > 0) {
-          File encryptedFile = File('${attachment.path}.aes');
-          await encryptFile(attachment, encryptedFile, _b64Secret!);
           saveImapMessage(_imapClient, subject, encryptedMessage,
               file: encryptedFile);
         }

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -156,11 +156,11 @@ class ImapCubit extends Cubit<ImapState> {
         if (fileLength > 0) {
           File encryptedFile = File('${attachment.path}.aes');
           await encryptFile(attachment, encryptedFile, _b64Secret!);
-          saveImapMessage(
-              _imapClient, subject, encryptedMessage, encryptedFile);
+          saveImapMessage(_imapClient, subject, encryptedMessage,
+              file: encryptedFile);
         }
       } else {
-        saveImapMessage(_imapClient, subject, encryptedMessage, null);
+        saveImapMessage(_imapClient, subject, encryptedMessage);
       }
     }
   }

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -27,7 +27,7 @@ class ImapCubit extends Cubit<ImapState> {
   late final ImapClient _imapClient;
   late final MailClient _mailClient;
   late SyncConfig? _syncConfig;
-  late String _b64Secret;
+  late String? _b64Secret;
 
   ImapCubit({
     required EncryptionCubit encryptionCubit,
@@ -155,7 +155,7 @@ class ImapCubit extends Cubit<ImapState> {
         int fileLength = attachment.lengthSync();
         if (fileLength > 0) {
           File encryptedFile = File('${attachment.path}.aes');
-          await encryptFile(attachment, encryptedFile, _b64Secret);
+          await encryptFile(attachment, encryptedFile, _b64Secret!);
           saveImapMessage(
               _imapClient, subject, encryptedMessage, encryptedFile);
         }

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -14,6 +14,7 @@ import 'package:wisely/blocs/sync/encryption_cubit.dart';
 import 'package:wisely/blocs/sync/imap_state.dart';
 import 'package:wisely/classes/journal_entities.dart';
 import 'package:wisely/classes/sync_message.dart';
+import 'package:wisely/utils/image_utils.dart';
 
 import '../journal_entities_cubit.dart';
 import 'imap_tools.dart';
@@ -139,22 +140,28 @@ class ImapCubit extends Cubit<ImapState> {
     }
   }
 
-  Future<void> saveImap(
+  Future<bool> saveImap(
     String encryptedMessage,
     String subject, {
     String? encryptedFilePath,
   }) async {
+    GenericImapResult? res;
     if (_b64Secret != null) {
-      if (encryptedFilePath != null) {
-        File encryptedFile = File(encryptedFilePath);
+      if (encryptedFilePath != null && encryptedFilePath.isNotEmpty) {
+        File encryptedFile = File(await getFullAssetPath(encryptedFilePath));
         int fileLength = encryptedFile.lengthSync();
         if (fileLength > 0) {
-          saveImapMessage(_imapClient, subject, encryptedMessage,
+          res = await saveImapMessage(_imapClient, subject, encryptedMessage,
               file: encryptedFile);
         }
       } else {
-        saveImapMessage(_imapClient, subject, encryptedMessage);
+        res = await saveImapMessage(_imapClient, subject, encryptedMessage);
       }
+    }
+    if (res?.details != null && res!.details!.contains('completed')) {
+      return true;
+    } else {
+      return false;
     }
   }
 }

--- a/wisely/lib/blocs/sync/imap_tools.dart
+++ b/wisely/lib/blocs/sync/imap_tools.dart
@@ -97,9 +97,9 @@ Future<void> writeToFile(Uint8List? data, String filePath) async {
 void saveImapMessage(
   ImapClient imapClient,
   String subject,
-  String encryptedMessage,
+  String encryptedMessage, {
   File? file,
-) async {
+}) async {
   Mailbox inbox = await imapClient.selectInbox();
   final builder = MessageBuilder.prepareMultipartAlternativeMessage();
   builder.from = [MailAddress('Sync', 'sender@domain.com')];

--- a/wisely/lib/blocs/sync/imap_tools.dart
+++ b/wisely/lib/blocs/sync/imap_tools.dart
@@ -116,5 +116,8 @@ void saveImapMessage(
   }
 
   final MimeMessage message = builder.buildMimeMessage();
-  imapClient.appendMessage(message, targetMailbox: inbox);
+  GenericImapResult res =
+      await imapClient.appendMessage(message, targetMailbox: inbox);
+  print(
+      'saveImapMessage responseCode ${res.responseCode} details ${res.details}');
 }

--- a/wisely/lib/blocs/sync/imap_tools.dart
+++ b/wisely/lib/blocs/sync/imap_tools.dart
@@ -94,7 +94,7 @@ Future<void> writeToFile(Uint8List? data, String filePath) async {
   }
 }
 
-void saveImapMessage(
+Future<GenericImapResult> saveImapMessage(
   ImapClient imapClient,
   String subject,
   String encryptedMessage, {
@@ -120,4 +120,5 @@ void saveImapMessage(
       await imapClient.appendMessage(message, targetMailbox: inbox);
   print(
       'saveImapMessage responseCode ${res.responseCode} details ${res.details}');
+  return res;
 }

--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -136,7 +136,9 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
         } else {
           update(
             nextPending,
-            OutboundMessageStatus.pending,
+            nextPending.retries < 10
+                ? OutboundMessageStatus.pending
+                : OutboundMessageStatus.error,
             nextPending.retries + 1,
           );
         }

--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -4,19 +4,16 @@ import 'dart:io';
 
 import 'package:bloc/bloc.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:flutter/services.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:mutex/mutex.dart';
-import 'package:path/path.dart';
-import 'package:sqflite/sqflite.dart';
 import 'package:wisely/blocs/sync/classes.dart';
 import 'package:wisely/blocs/sync/encryption_cubit.dart';
 import 'package:wisely/blocs/sync/imap_cubit.dart';
 import 'package:wisely/classes/sync_message.dart';
 import 'package:wisely/sync/encryption.dart';
 import 'package:wisely/sync/encryption_salsa.dart';
-import 'package:wisely/utils/image_utils.dart';
 
+import 'outbound_queue_db.dart';
 import 'outbound_queue_state.dart';
 
 class OutboundQueueCubit extends Cubit<OutboundQueueState> {
@@ -24,7 +21,7 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
   late final ImapCubit _imapCubit;
   final sendMutex = Mutex();
 
-  late final Future<Database> _database;
+  late final OutboundQueueDb _db;
   late String? _b64Secret;
 
   OutboundQueueCubit({
@@ -33,30 +30,12 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
   }) : super(OutboundQueueState.initial()) {
     _encryptionCubit = encryptionCubit;
     _imapCubit = imapCubit;
-    openDb();
+    _db = OutboundQueueDb();
+    init();
   }
 
-  Future<void> openDb() async {
-    String createDbStatement =
-        await rootBundle.loadString('assets/sqlite/create_outbound_db.sql');
-    emit(OutboundQueueState.loading());
-
-    String dbPath = join(await getDatabasesPath(), 'outbound.db');
-    print('OutboundQueueCubit DB Path: ${dbPath}');
-
-    _database = openDatabase(
-      dbPath,
-      onCreate: (db, version) async {
-        List<String> scripts = createDbStatement.split(";");
-        scripts.forEach((v) {
-          if (v.isNotEmpty) {
-            print(v.trim());
-            db.execute(v.trim());
-          }
-        });
-      },
-      version: 1,
-    );
+  Future<void> init() async {
+    await _db.openDb();
     SyncConfig? syncConfig = await _encryptionCubit.loadSyncConfig();
 
     if (syncConfig != null) {
@@ -66,59 +45,10 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
     _startPolling();
   }
 
-  Future<void> insert(
-    String encryptedMessage,
-    String subject, {
-    String? encryptedFilePath,
-  }) async {
-    final db = await _database;
-
-    OutboundQueueRecord dbRecord = OutboundQueueRecord(
-      encryptedMessage: encryptedMessage,
-      encryptedFilePath: getRelativeAssetPath(encryptedFilePath),
-      subject: subject,
-      status: OutboundMessageStatus.pending,
-      retries: 0,
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    );
-
-    await db.insert(
-      'outbound',
-      dbRecord.toMap(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
-  }
-
-  Future<void> update(
-    OutboundQueueRecord prev,
-    OutboundMessageStatus status,
-    int retries,
-  ) async {
-    final db = await _database;
-
-    OutboundQueueRecord dbRecord = OutboundQueueRecord(
-      id: prev.id,
-      encryptedMessage: prev.encryptedMessage,
-      subject: prev.subject,
-      status: status,
-      retries: retries,
-      createdAt: prev.createdAt,
-      updatedAt: DateTime.now(),
-    );
-    print('update $dbRecord');
-
-    await db.insert(
-      'outbound',
-      dbRecord.toMap(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
-  }
-
   void sendNext() async {
     var connectivityResult = await (Connectivity().checkConnectivity());
     if (connectivityResult != ConnectivityResult.none && !sendMutex.isLocked) {
-      List<OutboundQueueRecord> unprocessed = await oldestEntries();
+      List<OutboundQueueRecord> unprocessed = await _db.oldestEntries();
       if (unprocessed.isNotEmpty) {
         sendMutex.acquire();
         OutboundQueueRecord nextPending = unprocessed.first;
@@ -128,13 +58,13 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
           encryptedFilePath: nextPending.encryptedFilePath,
         );
         if (saveSuccess) {
-          update(
+          _db.update(
             nextPending,
             OutboundMessageStatus.sent,
             nextPending.retries,
           );
         } else {
-          update(
+          _db.update(
             nextPending,
             nextPending.retries < 10
                 ? OutboundMessageStatus.pending
@@ -154,30 +84,6 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
     });
   }
 
-  Future<List<OutboundQueueRecord>> entries() async {
-    final db = await _database;
-    final List<Map<String, dynamic>> maps = await db.query('outbound');
-
-    return List.generate(maps.length, (i) {
-      return OutboundQueueRecord.fromMap(maps[i]);
-    });
-  }
-
-  Future<List<OutboundQueueRecord>> oldestEntries() async {
-    final db = await _database;
-    final List<Map<String, dynamic>> maps = await db.query(
-      'outbound',
-      orderBy: 'created_at',
-      limit: 1,
-      where: 'status = ?',
-      whereArgs: [OutboundMessageStatus.pending.index],
-    );
-
-    return List.generate(maps.length, (i) {
-      return OutboundQueueRecord.fromMap(maps[i]);
-    });
-  }
-
   Future<void> enqueueMessage(
     SyncMessage syncMessage, {
     File? attachment,
@@ -192,11 +98,11 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
         if (fileLength > 0) {
           File encryptedFile = File('${attachment.path}.aes');
           await encryptFile(attachment, encryptedFile, _b64Secret!);
-          await insert(encryptedMessage, subject,
+          await _db.insert(encryptedMessage, subject,
               encryptedFilePath: encryptedFile.path);
         }
       } else {
-        await insert(encryptedMessage, subject);
+        await _db.insert(encryptedMessage, subject);
       }
     }
     sendNext();

--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter/services.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:wisely/blocs/sync/classes.dart';
+import 'package:wisely/blocs/sync/encryption_cubit.dart';
+import 'package:wisely/blocs/sync/imap_cubit.dart';
+import 'package:wisely/classes/sync_message.dart';
+import 'package:wisely/sync/encryption.dart';
+import 'package:wisely/sync/encryption_salsa.dart';
+
+import 'outbound_queue_state.dart';
+
+class OutboundQueueCubit extends Cubit<OutboundQueueState> {
+  late final EncryptionCubit _encryptionCubit;
+  late final ImapCubit _imapCubit;
+  late final Future<Database> _database;
+  late SyncConfig? _syncConfig;
+  late String _b64Secret;
+
+  OutboundQueueCubit({
+    required EncryptionCubit encryptionCubit,
+    required ImapCubit imapCubit,
+  }) : super(OutboundQueueState.initial()) {
+    _encryptionCubit = encryptionCubit;
+    _imapCubit = imapCubit;
+    openDb();
+  }
+
+  Future<void> openDb() async {
+    String createDbStatement =
+        await rootBundle.loadString('assets/sqlite/create_outbound_db.sql');
+    emit(OutboundQueueState.loading());
+
+    String dbPath = join(await getDatabasesPath(), 'outbound.db');
+    print('OutboundQueueCubit DB Path: ${dbPath}');
+
+    _database = openDatabase(
+      dbPath,
+      onCreate: (db, version) async {
+        List<String> scripts = createDbStatement.split(";");
+        scripts.forEach((v) {
+          if (v.isNotEmpty) {
+            print(v.trim());
+            db.execute(v.trim());
+          }
+        });
+      },
+      version: 1,
+    );
+    SyncConfig? syncConfig = await _encryptionCubit.loadSyncConfig();
+
+    if (syncConfig != null) {
+      _syncConfig = syncConfig;
+      _b64Secret = syncConfig.sharedSecret;
+    }
+    emit(OutboundQueueState.online());
+  }
+
+  Future<void> insert(String encryptedMessage, String subject) async {
+    final db = await _database;
+
+    Map<String, Object?> record = {
+      'created_at': DateTime.now().millisecondsSinceEpoch,
+      'status': OutboundMessageStatus.sent.index,
+      'message': encryptedMessage,
+      'subject': subject,
+    };
+
+    await db.insert(
+      'outbound',
+      record,
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> entries() async {
+    final db = await _database;
+    final List<Map<String, dynamic>> maps = await db.query('outbound');
+
+    return List.generate(maps.length, (i) {
+      return {
+        'id': maps[i]['_id'],
+        'created_at':
+            DateTime.fromMillisecondsSinceEpoch(maps[i]['created_at']),
+        'status': maps[i]['status'],
+        'message': json.decode(maps[i]['message']),
+      };
+    });
+  }
+
+  Future<void> enqueueSyncMessage(
+    SyncMessage syncMessage, {
+    File? attachment,
+  }) async {
+    String jsonString = json.encode(syncMessage);
+    String subject = syncMessage.vectorClock.toString();
+
+    if (_b64Secret != null) {
+      String encryptedMessage = encryptSalsa(jsonString, _b64Secret);
+      if (attachment != null) {
+        int fileLength = attachment.lengthSync();
+        if (fileLength > 0) {
+          File encryptedFile = File('${attachment.path}.aes');
+          await encryptFile(attachment, encryptedFile, _b64Secret);
+        }
+      } else {}
+      await insert(encryptedMessage, subject);
+
+      await _imapCubit.saveEncryptedImap(
+        syncMessage,
+        attachment: attachment,
+      );
+    }
+  }
+}

--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -64,32 +64,27 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
   Future<void> insert(String encryptedMessage, String subject) async {
     final db = await _database;
 
-    Map<String, Object?> record = {
-      'created_at': DateTime.now().millisecondsSinceEpoch,
-      'status': OutboundMessageStatus.sent.index,
-      'message': encryptedMessage,
-      'subject': subject,
-    };
+    OutboundQueueRecord dbRecord = OutboundQueueRecord(
+      encryptedMessage: encryptedMessage,
+      subject: subject,
+      status: OutboundMessageStatus.pending,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
 
     await db.insert(
       'outbound',
-      record,
+      dbRecord.toMap(),
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
   }
 
-  Future<List<Map<String, dynamic>>> entries() async {
+  Future<List<OutboundQueueRecord>> entries() async {
     final db = await _database;
     final List<Map<String, dynamic>> maps = await db.query('outbound');
 
     return List.generate(maps.length, (i) {
-      return {
-        'id': maps[i]['_id'],
-        'created_at':
-            DateTime.fromMillisecondsSinceEpoch(maps[i]['created_at']),
-        'status': maps[i]['status'],
-        'message': json.decode(maps[i]['message']),
-      };
+      return OutboundQueueRecord.fromMap(maps[i]);
     });
   }
 

--- a/wisely/lib/blocs/sync/outbound_queue_db.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_db.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:wisely/utils/image_utils.dart';
+
+import 'outbound_queue_state.dart';
+
+class OutboundQueueDb {
+  late final Future<Database> _database;
+
+  OutboundQueueDb() {}
+
+  Future<void> openDb() async {
+    String createDbStatement =
+        await rootBundle.loadString('assets/sqlite/create_outbound_db.sql');
+
+    String dbPath = join(await getDatabasesPath(), 'outbound.db');
+    print('OutboundQueueCubit DB Path: ${dbPath}');
+
+    _database = openDatabase(
+      dbPath,
+      onCreate: (db, version) async {
+        List<String> scripts = createDbStatement.split(";");
+        scripts.forEach((v) {
+          if (v.isNotEmpty) {
+            print(v.trim());
+            db.execute(v.trim());
+          }
+        });
+      },
+      version: 1,
+    );
+  }
+
+  Future<void> insert(
+    String encryptedMessage,
+    String subject, {
+    String? encryptedFilePath,
+  }) async {
+    final db = await _database;
+
+    OutboundQueueRecord dbRecord = OutboundQueueRecord(
+      encryptedMessage: encryptedMessage,
+      encryptedFilePath: getRelativeAssetPath(encryptedFilePath),
+      subject: subject,
+      status: OutboundMessageStatus.pending,
+      retries: 0,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    await db.insert(
+      'outbound',
+      dbRecord.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> update(
+    OutboundQueueRecord prev,
+    OutboundMessageStatus status,
+    int retries,
+  ) async {
+    final db = await _database;
+
+    OutboundQueueRecord dbRecord = OutboundQueueRecord(
+      id: prev.id,
+      encryptedMessage: prev.encryptedMessage,
+      subject: prev.subject,
+      status: status,
+      retries: retries,
+      createdAt: prev.createdAt,
+      updatedAt: DateTime.now(),
+    );
+
+    await db.insert(
+      'outbound',
+      dbRecord.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<List<OutboundQueueRecord>> oldestEntries() async {
+    final db = await _database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'outbound',
+      orderBy: 'created_at',
+      limit: 1,
+      where: 'status = ?',
+      whereArgs: [OutboundMessageStatus.pending.index],
+    );
+
+    return List.generate(maps.length, (i) {
+      return OutboundQueueRecord.fromMap(maps[i]);
+    });
+  }
+}

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -16,6 +16,7 @@ class OutboundQueueRecord {
   final int? id;
   final String encryptedMessage;
   final OutboundMessageStatus status;
+  final int retries;
   final String subject;
   final String? encryptedFilePath;
   final DateTime createdAt;
@@ -26,6 +27,7 @@ class OutboundQueueRecord {
     required this.encryptedMessage,
     required this.subject,
     required this.status,
+    required this.retries,
     required this.createdAt,
     this.encryptedFilePath,
     this.updatedAt,
@@ -42,6 +44,7 @@ class OutboundQueueRecord {
         encryptedMessage: data['message'],
         encryptedFilePath: data['encrypted_file_path'],
         status: OutboundMessageStatus.values[data['status']],
+        retries: data['retries'],
         subject: data['subject'],
         createdAt: DateTime.fromMillisecondsSinceEpoch(data['created_at']),
         updatedAt: DateTime.fromMillisecondsSinceEpoch(data['updated_at']),
@@ -52,7 +55,8 @@ class OutboundQueueRecord {
       'id': id,
       'created_at': createdAt.millisecondsSinceEpoch,
       'updated_at': updatedAt?.millisecondsSinceEpoch,
-      'status': OutboundMessageStatus.sent.index,
+      'status': status.index,
+      'retries': retries,
       'message': encryptedMessage,
       'encrypted_file_path': encryptedFilePath,
       'subject': subject,

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'outbound_queue_state.freezed.dart';
+
+@freezed
+class OutboundQueueState with _$OutboundQueueState {
+  factory OutboundQueueState.initial() = _Initial;
+  factory OutboundQueueState.loading() = _Loading;
+  factory OutboundQueueState.online() = _Online;
+  factory OutboundQueueState.failed() = _Failed;
+}

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wisely/classes/sync_message.dart';
 
 part 'outbound_queue_state.freezed.dart';
 
@@ -8,4 +9,42 @@ class OutboundQueueState with _$OutboundQueueState {
   factory OutboundQueueState.loading() = _Loading;
   factory OutboundQueueState.online() = _Online;
   factory OutboundQueueState.failed() = _Failed;
+}
+
+class OutboundQueueRecord {
+  final int? id;
+  final String encryptedMessage;
+  final OutboundMessageStatus status;
+  final String subject;
+  final DateTime createdAt;
+  DateTime? updatedAt;
+
+  OutboundQueueRecord({
+    this.id,
+    required this.encryptedMessage,
+    required this.subject,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory OutboundQueueRecord.fromMap(Map<String, dynamic> data) =>
+      OutboundQueueRecord(
+          id: data['id'],
+          encryptedMessage: data['message'],
+          status: data['status'],
+          subject: data['subject'],
+          createdAt: data['created_at'],
+          updatedAt: data['updated_at']);
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'updated_at': updatedAt?.millisecondsSinceEpoch,
+      'status': OutboundMessageStatus.sent.index,
+      'message': encryptedMessage,
+      'subject': subject,
+    };
+  }
 }

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -31,15 +31,21 @@ class OutboundQueueRecord {
     this.updatedAt,
   });
 
+  @override
+  String toString() {
+    return '$id $status $subject $createdAt $updatedAt';
+  }
+
   factory OutboundQueueRecord.fromMap(Map<String, dynamic> data) =>
       OutboundQueueRecord(
-          id: data['id'],
-          encryptedMessage: data['message'],
-          encryptedFilePath: data['encrypted_file_path'],
-          status: data['status'],
-          subject: data['subject'],
-          createdAt: data['created_at'],
-          updatedAt: data['updated_at']);
+        id: data['id'],
+        encryptedMessage: data['message'],
+        encryptedFilePath: data['encrypted_file_path'],
+        status: OutboundMessageStatus.values[data['status']],
+        subject: data['subject'],
+        createdAt: DateTime.fromMillisecondsSinceEpoch(data['created_at']),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(data['updated_at']),
+      );
 
   Map<String, Object?> toMap() {
     return {

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:wisely/classes/sync_message.dart';
 
 part 'outbound_queue_state.freezed.dart';
 
@@ -11,11 +10,14 @@ class OutboundQueueState with _$OutboundQueueState {
   factory OutboundQueueState.failed() = _Failed;
 }
 
+enum OutboundMessageStatus { pending, sent, error }
+
 class OutboundQueueRecord {
   final int? id;
   final String encryptedMessage;
   final OutboundMessageStatus status;
   final String subject;
+  final String? encryptedFilePath;
   final DateTime createdAt;
   DateTime? updatedAt;
 
@@ -25,7 +27,8 @@ class OutboundQueueRecord {
     required this.subject,
     required this.status,
     required this.createdAt,
-    required this.updatedAt,
+    this.encryptedFilePath,
+    this.updatedAt,
   });
 
   factory OutboundQueueRecord.fromMap(Map<String, dynamic> data) =>

--- a/wisely/lib/blocs/sync/outbound_queue_state.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_state.dart
@@ -35,6 +35,7 @@ class OutboundQueueRecord {
       OutboundQueueRecord(
           id: data['id'],
           encryptedMessage: data['message'],
+          encryptedFilePath: data['encrypted_file_path'],
           status: data['status'],
           subject: data['subject'],
           createdAt: data['created_at'],
@@ -47,6 +48,7 @@ class OutboundQueueRecord {
       'updated_at': updatedAt?.millisecondsSinceEpoch,
       'status': OutboundMessageStatus.sent.index,
       'message': encryptedMessage,
+      'encrypted_file_path': encryptedFilePath,
       'subject': subject,
     };
   }

--- a/wisely/lib/classes/sync_message.dart
+++ b/wisely/lib/classes/sync_message.dart
@@ -15,5 +15,3 @@ class SyncMessage with _$SyncMessage {
   factory SyncMessage.fromJson(Map<String, dynamic> json) =>
       _$SyncMessageFromJson(json);
 }
-
-enum OutboundMessageStatus { pending, sent, error }

--- a/wisely/lib/classes/sync_message.dart
+++ b/wisely/lib/classes/sync_message.dart
@@ -15,3 +15,5 @@ class SyncMessage with _$SyncMessage {
   factory SyncMessage.fromJson(Map<String, dynamic> json) =>
       _$SyncMessageFromJson(json);
 }
+
+enum OutboundMessageStatus { pending, sent, error }

--- a/wisely/lib/main.dart
+++ b/wisely/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:wisely/sync/secure_storage.dart';
 import 'package:wisely/theme.dart';
 
 import 'blocs/journal/journal_cubit.dart';
+import 'blocs/sync/outbound_queue_cubit.dart';
 import 'blocs/sync/vector_clock_cubit.dart';
 
 void main() async {
@@ -55,10 +56,17 @@ class WiselyApp extends StatelessWidget {
                 BlocProvider.of<JournalEntitiesCubit>(context),
           ),
         ),
+        BlocProvider<OutboundQueueCubit>(
+          lazy: false,
+          create: (BuildContext context) => OutboundQueueCubit(
+            encryptionCubit: BlocProvider.of<EncryptionCubit>(context),
+            imapCubit: BlocProvider.of<ImapCubit>(context),
+          ),
+        ),
         BlocProvider<JournalCubit>(
           lazy: false,
           create: (BuildContext context) => JournalCubit(
-            imapCubit: BlocProvider.of<ImapCubit>(context),
+            outboundQueueCubit: BlocProvider.of<OutboundQueueCubit>(context),
             vectorClockCubit: BlocProvider.of<VectorClockCubit>(context),
             journalEntitiesCubit:
                 BlocProvider.of<JournalEntitiesCubit>(context),

--- a/wisely/lib/main.dart
+++ b/wisely/lib/main.dart
@@ -74,7 +74,7 @@ class WiselyApp extends StatelessWidget {
         ),
         BlocProvider<AudioRecorderCubit>(
           create: (BuildContext context) => AudioRecorderCubit(
-            imapCubit: BlocProvider.of<ImapCubit>(context),
+            outboundQueueCubit: BlocProvider.of<OutboundQueueCubit>(context),
             journalEntitiesCubit:
                 BlocProvider.of<JournalEntitiesCubit>(context),
             vectorClockCubit: BlocProvider.of<VectorClockCubit>(context),

--- a/wisely/lib/utils/image_utils.dart
+++ b/wisely/lib/utils/image_utils.dart
@@ -112,9 +112,13 @@ Future<File?> compressAndSave(File file, String targetPath) async {
   return result;
 }
 
-Future<String> getImagePath(String relativePath) async {
+Future<String> getFullAssetPath(String relativePath) async {
   var docDir = await getApplicationDocumentsDirectory();
   return '${docDir.path}$relativePath';
+}
+
+String? getRelativeAssetPath(String? absolutePath) {
+  return absolutePath?.split('Documents').last;
 }
 
 Future<String> getFullImagePath(JournalImage img) async {

--- a/wisely/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/wisely/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import audio_session
+import connectivity_plus_macos
 import device_info_plus_macos
 import flutter_native_timezone
 import flutter_secure_storage_macos
@@ -18,6 +19,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   FlutterSecureStorageMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageMacosPlugin"))

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   wechat_assets_picker: ^6.2.2
   dart_geohash: ^2.0.1
   device_info_plus: ^3.1.0
+  mutex: ^3.0.0
+  connectivity_plus: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -68,7 +68,7 @@ flutter:
   uses-material-design: true
 
   assets:
-    - assets/sqlite/create_db.sql
+    - assets/sqlite/
     # from https://www.iconfinder.com/paomedia
     - assets/images/map/299087_marker_map_icon.png
     # from https://www.iconfinder.com/recepkutuk


### PR DESCRIPTION
This PR adds an outbound queue for sync messages, which are persisted to the database first, and then only processed one by one when the device is connected to a network. It would be possible later to only upload large files when on wifi. For now, I want them always saved right away. Every 10 seconds the the queue cubit looks for an as yet unprocessed item, and on successful save updates the record status. This is retried ten times. On success, the next dispatch is started right away, same on every enqueuing. A mutex prevents running multiple at the same time, so that not worst case hundreds are started at the same time when importing a bunch of photos.