### PR TITLE
Simplify import directory picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.345",
+  "version": "0.6.346",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.345",
+  "version": "0.6.346",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/menu.cljs
+++ b/src/cljs/meins/electron/main/menu.cljs
@@ -60,17 +60,11 @@
                      (put-fn [:import/photos files])))]
     (.showOpenDialog dialog options callback)))
 
-(defn import-audio-dialog [put-fn]
+(defn import-media-dialog [put-fn]
   (let [options (clj->js {:properties  ["openDirectory"]
-                          :buttonLabel "Import"})
+                          :buttonLabel "Import Documents"})
         selected-dir (first (js->clj (.showOpenDialogSync dialog options)))]
-    (put-fn [:import/audio {:directory selected-dir}])))
-
-(defn import-images-dialog [put-fn]
-  (let [options (clj->js {:properties  ["openDirectory"]
-                          :buttonLabel "Import"})
-        selected-dir (first (js->clj (.showOpenDialogSync dialog options)))]
-    (put-fn [:import/images {:directory selected-dir}])))
+    (put-fn [:import/media {:directory selected-dir}])))
 
 (defn import-health-dialog [put-fn]
   (let [options (clj->js {:properties  ["openFile" "multiSelections"]
@@ -129,10 +123,8 @@
                 :submenu [{:label       "Photos"
                            :accelerator "CmdOrCtrl+I"
                            :click       #(import-dialog put-fn)}
-                          {:label "Audio from Flutter app"
-                           :click #(import-audio-dialog put-fn)}
-                          {:label "Images from Flutter app"
-                           :click #(import-images-dialog put-fn)}
+                          {:label "Media from Flutter app"
+                           :click #(import-media-dialog put-fn)}
                           {:label "Health Data from Flutter app"
                            :click #(import-health-dialog put-fn)}
                           (when (contains? capabilities :git-import)


### PR DESCRIPTION
This PR replaces separate selection of audio and image import directories with a single directory picker for the flutter container `Documents` directory.