### PR TITLE
poll for new messages every 30s, restart mailbox observation

### DIFF
--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.43+44
+version: 0.1.44+45
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR increases the polling frequency and restarts the mailbox observation, which seems to be a bit unreliable at its current state.