### PR TITLE
only log connection status when not connected

### DIFF
--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -119,7 +119,7 @@ class ImapCubit extends Cubit<ImapState> {
 
   void _startPolling() async {
     debugPrint('_startPolling');
-    Timer.periodic(const Duration(seconds: 20), (timer) async {
+    Timer.periodic(const Duration(seconds: 10), (timer) async {
       _pollInbox();
       _observeInbox();
     });

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.45+47
+version: 0.1.46+48
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR reduces logging of the connection status, it will only do so when not connection, as successful connections are the norm and not worth cluttering Sentry.