### PR TITLE
fix connection status reporting

### DIFF
--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -77,7 +77,7 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
       _connectivityResult = await Connectivity().checkConnectivity();
       debugPrint('sendNext Connectivity $_connectivityResult');
 
-      if (_connectivityResult != ConnectivityResult.none) {
+      if (_connectivityResult == ConnectivityResult.none) {
         reportConnectivity();
       }
 

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.46+50
+version: 0.1.46+51
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes the reporting of the connection status. It's only worth reporting when there is no connection, whereas previously, the test was the opposite way to report when the status was not `ConnectivityResult.none`.