### PR TITLE
Refactor journal entities

### DIFF
--- a/wisely/Makefile
+++ b/wisely/Makefile
@@ -23,13 +23,9 @@ check-null-safety:
 build_runner:
 	flutter pub run build_runner build --delete-conflicting-outputs
 
-.PHONY: build_runner_watch
-build_runner_watch:
+.PHONY: watch
+watch:
 	flutter pub run build_runner watch --delete-conflicting-outputs
-
-.PHONY: build_runner_watch2
-build_runner_watch2:
-	flutter pub run build_runner watch --delete-conflicting-outputs --use-polling-watcher
 
 .PHONY: bundle
 bundle:

--- a/wisely/analysis_options.yaml
+++ b/wisely/analysis_options.yaml
@@ -31,6 +31,5 @@ linter:
 analyzer:
   exclude:
     - "**/*.g.dart"
-    - "**/*.freezed.dart"
   errors:
     invalid_annotation_target: ignore

--- a/wisely/lib/classes/journal_entities.dart
+++ b/wisely/lib/classes/journal_entities.dart
@@ -1,0 +1,192 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wisely/classes/geolocation.dart';
+import 'package:wisely/classes/task.dart';
+import 'package:wisely/sync/vector_clock.dart';
+
+import 'check_list_item.dart';
+import 'entry_text.dart';
+
+part 'journal_entities.freezed.dart';
+part 'journal_entities.g.dart';
+
+abstract class CommonJournalFields {
+  String get id;
+  DateTime get createdAt;
+  DateTime get updatedAt;
+  DateTime get dateFrom;
+  DateTime get dateTo;
+  int? get utcOffset;
+  String? get timezone;
+  VectorClock? get vectorClock;
+}
+
+abstract class TextJournalFields {
+  EntryText? get entryText;
+}
+
+abstract class GeoJournalFields {
+  Geolocation? get geolocation;
+}
+
+abstract class LinkedJournalFields {
+  List<String> get linkedIds;
+}
+
+@freezed
+class JournalEntity with _$JournalEntity {
+  @Implements<CommonJournalFields>()
+  @Implements<TextJournalFields>()
+  @Implements<GeoJournalFields>()
+  factory JournalEntity.journalEntry({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // shared fields:
+    EntryText? entryText,
+    Geolocation? geolocation,
+    // end shared fields
+  }) = JournalEntry;
+
+  @Implements<CommonJournalFields>()
+  @Implements<TextJournalFields>()
+  @Implements<GeoJournalFields>()
+  const factory JournalEntity.journalDbImage({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // shared fields:
+    EntryText? entryText,
+    Geolocation? geolocation,
+    // end shared fields
+
+    required DateTime capturedAt,
+    required String imageId,
+    required String imageFile,
+    required String imageDirectory,
+  }) = JournalDbImage;
+
+  @Implements<CommonJournalFields>()
+  @Implements<TextJournalFields>()
+  @Implements<GeoJournalFields>()
+  const factory JournalEntity.journalDbAudio({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // shared fields:
+    EntryText? entryText,
+    Geolocation? geolocation,
+    // end shared fields
+
+    required String audioFile,
+    required String audioDirectory,
+    required Duration duration,
+    String? transcript,
+  }) = JournalDbAudio;
+
+  @Implements<CommonJournalFields>()
+  @Implements<TextJournalFields>()
+  @Implements<GeoJournalFields>()
+  const factory JournalEntity.loggedTime({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // shared fields:
+    EntryText? entryText,
+    Geolocation? geolocation,
+    // end shared fields
+  }) = LoggedTime;
+
+  @Implements<CommonJournalFields>()
+  @Implements<TextJournalFields>()
+  @Implements<GeoJournalFields>()
+  const factory JournalEntity.task({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // shared fields:
+    EntryText? entryText,
+    Geolocation? geolocation,
+    // end shared fields
+
+    required TaskStatus status,
+    required List<TaskStatus> statusHistory,
+    required String title,
+    List<CheckListItem>? checklist,
+  }) = Task;
+
+  @Implements<CommonJournalFields>()
+  const factory JournalEntity.cumulativeQuantity({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // common fields end
+
+    required num value,
+    required String dataType,
+    required String unit,
+    String? deviceType,
+    String? platformType,
+  }) = CumulativeQuantity;
+
+  @Implements<CommonJournalFields>()
+  const factory JournalEntity.discreteQuantity({
+    // common fields:
+    required String id,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required DateTime dateFrom,
+    required DateTime dateTo,
+    int? utcOffset,
+    String? timezone,
+    VectorClock? vectorClock,
+    // common fields end
+
+    required num value,
+    required String dataType,
+    required String unit,
+    String? deviceType,
+    String? platformType,
+    String? sourceName,
+    String? sourceId,
+    String? deviceId,
+  }) = DiscreteQuantity;
+
+  factory JournalEntity.fromJson(Map<String, dynamic> json) =>
+      _$JournalEntityFromJson(json);
+}

--- a/wisely/lib/widgets/journal_list_item.dart
+++ b/wisely/lib/widgets/journal_list_item.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:provider/src/provider.dart';
+import 'package:provider/provider.dart';
 import 'package:wisely/blocs/audio/player_cubit.dart';
 import 'package:wisely/classes/journal_db_entities.dart';
 import 'package:wisely/utils/image_utils.dart';


### PR DESCRIPTION
This PR introduces a simpler `JournalEntity` union type so that the sometimes cumbersome nesting can be removed. Requires including the output of the `freezed` generator in the Dart analysis - otherwise, missing implementation would not be reported at dev time.