### PR TITLE
Remove conversion on import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ npm-deps:
 	@npm install -g electron-builder
 	@npx electron-rebuild -v 13.1.7 -w keytar
 
-test: deps
+test: deps cljs-shared-tests
 	@echo Running Clojure tests...
 	@lein test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.353",
+  "version": "0.6.354",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.353",
+  "version": "0.6.354",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/import/images.cljs
+++ b/src/cljs/meins/electron/main/import/images.cljs
@@ -52,26 +52,25 @@
     entry))
 
 (defn import-image-files [path put-fn]
-  (let [files (sync (str path "/**/*.HEIC.json"))]
+  (let [files (sync (str path "/**/*.+(JPG|JPEG|jpg|jpeg).json"))]
     (doseq [json-file files]
       (when-not (s/includes? json-file "trash")
         (let [data (h/parse-json json-file)
               entry (convert-new-image-entry data)
               file (str/replace json-file ".json" "")
-              jpg (s/replace file "HEIC" "JPG")
               img-file (:img_file entry)
               img-file-path (str @image-path-atom "/" img-file)]
           (info (exp/expound-str :meins.entry/spec entry))
-          (pp/pprint entry)
           (when-not (existsSync img-file-path)
             (when (existsSync file)
+              (info "importing" file)
               (js/setTimeout #(when (spec/valid? :meins.entry/spec entry)
                                 (info "spec/valid")
-                                (info jpg img-file-path)
-                                (copyFileSync jpg img-file-path)
+                                (info file img-file-path)
+                                (copyFileSync file img-file-path)
                                 (put-fn [:import/gen-thumbs
                                          {:filename  img-file
-                                          :full-path jpg}]))
+                                          :full-path file}]))
                              2000)
               (js/setTimeout #(when (spec/valid? :meins.entry/spec entry)
                                 (put-fn [:entry/save-initial entry]))

--- a/src/cljs/meins/electron/main/import/images.cljs
+++ b/src/cljs/meins/electron/main/import/images.cljs
@@ -5,7 +5,6 @@
             [clojure.string :as str]
             [meins.electron.main.helpers :as h]
             [cljs.spec.alpha :as spec]
-            ["child_process" :refer [spawn]]
             ["moment" :as moment]
             [clojure.pprint :as pp]
             [expound.alpha :as exp]
@@ -52,10 +51,6 @@
                :vclock     (get meta-data "vectorClock")}]
     entry))
 
-(defn spawn-process [cmd args opts]
-  (info "STARTUP: spawning" cmd args opts)
-  (spawn cmd (clj->js args) (clj->js opts)))
-
 (defn import-image-files [path put-fn]
   (let [files (sync (str path "/**/*.HEIC.json"))]
     (doseq [json-file files]
@@ -70,7 +65,6 @@
           (pp/pprint entry)
           (when-not (existsSync img-file-path)
             (when (existsSync file)
-              (spawn-process "/usr/local/bin/magick" ["convert" file jpg] {})
               (js/setTimeout #(when (spec/valid? :meins.entry/spec entry)
                                 (info "spec/valid")
                                 (info jpg img-file-path)


### PR DESCRIPTION
This PR removes the conversion to JPG within the import routine in meins - images now come as JPG anyway. HEIC was causing issues on desktop in release versions only - and in dev, was way, way slower to load than JPG. In terms of space usage, that's a shame, but proper support of the archive image format is more important. 