### PR TITLE
Fix missing attachment on retry

### DIFF
--- a/wisely/lib/blocs/sync/imap_out_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_out_cubit.dart
@@ -96,7 +96,7 @@ class ImapOutCubit extends Cubit<ImapState> {
         exception,
         stackTrace: stackTrace,
       );
-      return false;
+      rethrow;
     }
   }
 }

--- a/wisely/lib/blocs/sync/imap_tools.dart
+++ b/wisely/lib/blocs/sync/imap_tools.dart
@@ -107,27 +107,35 @@ Future<GenericImapResult> saveImapMessage(
   String encryptedMessage, {
   File? file,
 }) async {
-  final transaction = Sentry.startTransaction('saveImapMessage()', 'task');
-  Mailbox inbox = await imapClient.selectInbox();
-  final builder = MessageBuilder.prepareMultipartAlternativeMessage();
-  builder.from = [MailAddress('Sync', 'sender@domain.com')];
-  builder.to = [MailAddress('Sync', 'recipient@domain.com')];
-  builder.subject = subject;
-  builder.addTextPlain(encryptedMessage);
+  try {
+    final transaction = Sentry.startTransaction('saveImapMessage()', 'task');
+    Mailbox inbox = await imapClient.selectInbox();
+    final builder = MessageBuilder.prepareMultipartAlternativeMessage();
+    builder.from = [MailAddress('Sync', 'sender@domain.com')];
+    builder.to = [MailAddress('Sync', 'recipient@domain.com')];
+    builder.subject = subject;
+    builder.addTextPlain(encryptedMessage);
 
-  if (file != null) {
-    int fileLength = file.lengthSync();
-    if (fileLength > 0) {
-      await builder.addFile(
-          file, MediaType.fromText('application/octet-stream'));
+    if (file != null) {
+      int fileLength = file.lengthSync();
+      if (fileLength > 0) {
+        await builder.addFile(
+            file, MediaType.fromText('application/octet-stream'));
+      }
     }
-  }
 
-  final MimeMessage message = builder.buildMimeMessage();
-  GenericImapResult res =
-      await imapClient.appendMessage(message, targetMailbox: inbox);
-  debugPrint(
-      'saveImapMessage responseCode ${res.responseCode} details ${res.details}');
-  await transaction.finish();
-  return res;
+    final MimeMessage message = builder.buildMimeMessage();
+    GenericImapResult res =
+        await imapClient.appendMessage(message, targetMailbox: inbox);
+    debugPrint(
+        'saveImapMessage responseCode ${res.responseCode} details ${res.details}');
+    await transaction.finish();
+    return res;
+  } catch (exception, stackTrace) {
+    await Sentry.captureException(
+      exception,
+      stackTrace: stackTrace,
+    );
+    rethrow;
+  }
 }

--- a/wisely/lib/blocs/sync/outbound_queue_db.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_db.dart
@@ -97,6 +97,7 @@ class OutboundQueueDb {
         retries: retries,
         createdAt: prev.createdAt,
         updatedAt: DateTime.now(),
+        encryptedFilePath: prev.encryptedFilePath,
       );
 
       await db.insert(

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.50+57
+version: 0.1.51+58
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes an issue with missing attachments. The problem was that on (relatively rare) retry, the `encryptedFilePath` was not kept but rather overwritten with `NULL`. On the next retry, sending was initiated for the entry itself, but not for the attachment.

![image](https://user-images.githubusercontent.com/1390808/141218232-31b62652-6f19-44cb-9592-d86c808ed313.png)
