### PR TITLE
disable restarting folder watch

### DIFF
--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -114,9 +114,8 @@ class ImapCubit extends Cubit<ImapState> {
   }
 
   void _startPolling() async {
-    Timer.periodic(const Duration(seconds: 10), (timer) async {
+    Timer.periodic(const Duration(seconds: 30), (timer) async {
       _pollInbox();
-      _observeInbox();
     });
   }
 
@@ -189,7 +188,6 @@ class ImapCubit extends Cubit<ImapState> {
   Future<void> _observeInbox() async {
     try {
       if (_syncConfig != null) {
-        _mailClient.stopPollingIfNeeded();
         ImapConfig imapConfig = _syncConfig!.imapConfig;
         final account = MailAccount.fromManualSettings(
           'sync',
@@ -217,7 +215,6 @@ class ImapCubit extends Cubit<ImapState> {
                 message: SentryMessage(event.toString()),
               ),
               withScope: (Scope scope) => scope.level = SentryLevel.warning);
-          _observeInbox();
         });
 
         _mailClient.startPolling();

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.51+58
+version: 0.1.52+59
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR disables restarting the folder watch for now until focusing on the IMAP client again. This will get rid of a bunch of errors reported by Sentry.