### PR TITLE
limit health queries: up to the query time

### DIFF
--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.52+59
+version: 0.1.53+60
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR limits health query end dates to be at most now (as in the query time). Going into the future doesn't make sense - there cannot be evidence for future events yet. This also makes the import into meins easier.