### PR TITLE
Resume polling after sleep

### DIFF
--- a/wisely/ios/Podfile.lock
+++ b/wisely/ios/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_fgbg (0.0.1):
+    - Flutter
   - flutter_health_fit (0.0.1):
     - Flutter
   - flutter_image_compress (0.0.1):
@@ -97,6 +99,7 @@ DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
+  - flutter_fgbg (from `.symlinks/plugins/flutter_fgbg/ios`)
   - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress (from `.symlinks/plugins/flutter_image_compress/ios`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
@@ -141,6 +144,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
+  flutter_fgbg:
+    :path: ".symlinks/plugins/flutter_fgbg/ios"
   flutter_health_fit:
     :path: ".symlinks/plugins/flutter_health_fit/ios"
   flutter_image_compress:
@@ -187,6 +192,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 5f0eb61093bec56935f21a1699dd2758bc895587
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_health_fit: a96be00d6d54c5853fc0d5e08204d0d6821517ed
   flutter_image_compress: fd2b476345226e1a10ea352fa306af95704642c1
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721

--- a/wisely/lib/blocs/journal/persistence_cubit.dart
+++ b/wisely/lib/blocs/journal/persistence_cubit.dart
@@ -217,8 +217,10 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       bool saved = await _db.insert(journalEntity);
 
       if (saved && enqueueSync) {
-        _outboundQueueCubit.enqueueMessage(
-            SyncMessage.journalDbEntity(journalEntity: journalEntity));
+        _outboundQueueCubit.enqueueMessage(SyncMessage.journalDbEntity(
+          journalEntity: journalEntity,
+          status: SyncEntryStatus.initial,
+        ));
       }
       await transaction.finish();
 

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -10,6 +10,7 @@ import 'package:enough_mail/mail/mail_events.dart';
 import 'package:enough_mail/mail/mail_exception.dart';
 import 'package:enough_mail/mime_message.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:wisely/blocs/journal/persistence_cubit.dart';
@@ -31,6 +32,8 @@ class ImapCubit extends Cubit<ImapState> {
   late final MailClient _mailClient;
   late SyncConfig? _syncConfig;
   late String? _b64Secret;
+  late final StreamSubscription<FGBGType> fgBgSubscription;
+  Timer? timer;
 
   final _storage = const FlutterSecureStorage();
   final String sharedSecretKey = 'sharedSecret';
@@ -47,6 +50,20 @@ class ImapCubit extends Cubit<ImapState> {
     _vectorClockCubit = vectorClockCubit;
     _imapClient = ImapClient(isLogEnabled: false);
     imapClientInit();
+
+    fgBgSubscription = FGBGEvents.stream.listen((event) {
+      Sentry.captureEvent(
+          SentryEvent(
+            message: SentryMessage(event.toString()),
+          ),
+          withScope: (Scope scope) => scope.level = SentryLevel.info);
+      if (event == FGBGType.foreground) {
+        _startPolling();
+      }
+      if (event == FGBGType.background) {
+        _stopPolling();
+      }
+    });
   }
 
   Future<void> processMessage(MimeMessage message) async {
@@ -131,9 +148,15 @@ class ImapCubit extends Cubit<ImapState> {
   }
 
   void _startPolling() async {
-    Timer.periodic(const Duration(seconds: 30), (timer) async {
+    timer = Timer.periodic(const Duration(seconds: 30), (timer) async {
       _pollInbox();
     });
+  }
+
+  void _stopPolling() async {
+    if (timer != null) {
+      timer!.cancel();
+    }
   }
 
   Future<void> _pollInbox() async {

--- a/wisely/lib/blocs/sync/imap_cubit.dart
+++ b/wisely/lib/blocs/sync/imap_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc/bloc.dart';
 import 'package:enough_mail/imap/imap_client.dart';
@@ -51,19 +52,21 @@ class ImapCubit extends Cubit<ImapState> {
     _imapClient = ImapClient(isLogEnabled: false);
     imapClientInit();
 
-    fgBgSubscription = FGBGEvents.stream.listen((event) {
-      Sentry.captureEvent(
-          SentryEvent(
-            message: SentryMessage(event.toString()),
-          ),
-          withScope: (Scope scope) => scope.level = SentryLevel.info);
-      if (event == FGBGType.foreground) {
-        _startPolling();
-      }
-      if (event == FGBGType.background) {
-        _stopPolling();
-      }
-    });
+    if (!Platform.isMacOS) {
+      fgBgSubscription = FGBGEvents.stream.listen((event) {
+        Sentry.captureEvent(
+            SentryEvent(
+              message: SentryMessage(event.toString()),
+            ),
+            withScope: (Scope scope) => scope.level = SentryLevel.info);
+        if (event == FGBGType.foreground) {
+          _startPolling();
+        }
+        if (event == FGBGType.background) {
+          _stopPolling();
+        }
+      });
+    }
   }
 
   Future<void> processMessage(MimeMessage message) async {

--- a/wisely/lib/blocs/sync/outbound_queue_cubit.dart
+++ b/wisely/lib/blocs/sync/outbound_queue_cubit.dart
@@ -52,19 +52,21 @@ class OutboundQueueCubit extends Cubit<OutboundQueueState> {
       debugPrint('Connectivity onConnectivityChanged $result');
     });
 
-    fgBgSubscription = FGBGEvents.stream.listen((event) {
-      Sentry.captureEvent(
-          SentryEvent(
-            message: SentryMessage(event.toString()),
-          ),
-          withScope: (Scope scope) => scope.level = SentryLevel.info);
-      if (event == FGBGType.foreground) {
-        _startPolling();
-      }
-      if (event == FGBGType.background) {
-        _stopPolling();
-      }
-    });
+    if (!Platform.isMacOS) {
+      fgBgSubscription = FGBGEvents.stream.listen((event) {
+        Sentry.captureEvent(
+            SentryEvent(
+              message: SentryMessage(event.toString()),
+            ),
+            withScope: (Scope scope) => scope.level = SentryLevel.info);
+        if (event == FGBGType.foreground) {
+          _startPolling();
+        }
+        if (event == FGBGType.background) {
+          _stopPolling();
+        }
+      });
+    }
   }
 
   Future<void> init() async {

--- a/wisely/lib/classes/sync_message.dart
+++ b/wisely/lib/classes/sync_message.dart
@@ -11,7 +11,7 @@ enum SyncEntryStatus { initial, update }
 class SyncMessage with _$SyncMessage {
   factory SyncMessage.journalDbEntity({
     required JournalEntity journalEntity,
-    @Default(SyncEntryStatus.initial) SyncEntryStatus status,
+    required SyncEntryStatus status,
   }) = SyncJournalDbEntity;
 
   factory SyncMessage.fromJson(Map<String, dynamic> json) =>

--- a/wisely/pubspec.lock
+++ b/wisely/pubspec.lock
@@ -538,6 +538,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.2"
+  flutter_fgbg:
+    dependency: "direct main"
+    description:
+      name: flutter_fgbg
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   flutter_form_builder:
     dependency: "direct main"
     description:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.64+75
+version: 0.1.64+78
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.64+74
+version: 0.1.64+75
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.63+72
+version: 0.1.63+73
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.63+73
+version: 0.1.64+74
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.62+71
+version: 0.1.63+72
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -60,6 +60,7 @@ dependencies:
   package_info_plus: ^1.3.0
   keyboard_dismisser: ^2.0.0
   crypto: ^3.0.1
+  flutter_fgbg: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds detecting the foreground/background status on mobile so that the polling for sync messages can be resumed when the app comes back into the foreground.