### PR TITLE
upgrade freezed

### DIFF
--- a/wisely/pubspec.lock
+++ b/wisely/pubspec.lock
@@ -722,14 +722,14 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.1+1"
+    version: "1.0.0"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "1.0.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.65+79
+version: 0.1.66+80
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -37,7 +37,7 @@ dependencies:
   flutter_quill: ^2.0.9
   flutter_secure_storage: ^5.0.0
   flutter_sound: ^8.3.12
-  freezed_annotation: ^0.15.0
+  freezed_annotation: ^1.0.0
   health: ^3.1.1+1
   hydrated_bloc: 8.0.0-dev.4
   intl: ^0.17.0
@@ -69,7 +69,7 @@ dev_dependencies:
   dart_code_metrics: ^4.6.0
   flutter_lints: ^1.0.0
   flutter_native_splash: ^1.3.1
-  freezed: ^0.15.0+1
+  freezed: ^1.0.0
   glados: ^1.0.2
   json_serializable: ^6.0.0
   sentry_dart_plugin: ^1.0.0-beta.1


### PR DESCRIPTION
This PR upgrades `freezed`. Unfortunately a breaking change in the serialization format. Hopefully, this will be a one time thing, now that the library has reached `1.0.0`.