### PR TITLE
fix weight import by locking health lib to 3.2.1

### DIFF
--- a/wisely/pubspec.lock
+++ b/wisely/pubspec.lock
@@ -778,7 +778,7 @@ packages:
       name: health
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.2.1"
   hive:
     dependency: transitive
     description:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.66+80
+version: 0.1.67+81
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -38,7 +38,7 @@ dependencies:
   flutter_secure_storage: ^5.0.0
   flutter_sound: ^8.3.12
   freezed_annotation: ^1.0.0
-  health: ^3.1.1+1
+  health: 3.2.1
   hydrated_bloc: 8.0.0-dev.4
   intl: ^0.17.0
   json_annotation: ^4.3.0


### PR DESCRIPTION
Version 3.3.1 returned weight as pounds, while still indicating a unit of kilograms. I created an [issue](https://github.com/cph-cachet/flutter-plugins/issues/460) in the health lib. For now, locking the version to `3.2.1` fixes the issue. 