### PR TITLE
persist flutter container documents path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.354",
+  "version": "0.6.355",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.354",
+  "version": "0.6.355",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/import/core.cljs
+++ b/src/cljs/meins/electron/main/import/core.cljs
@@ -1,18 +1,41 @@
 (ns meins.electron.main.import.core
   (:require [taoensso.timbre :refer [error info]]
+            ["fs" :refer [existsSync readFileSync writeFileSync]]
             [meins.electron.main.import.audio :as ai]
+            [meins.electron.main.runtime :as rt]
+            [cljs.reader :refer [read-string]]
             [meins.electron.main.import.health :as hi]
             [meins.electron.main.import.images :as ii]))
 
-(defn import-media [{:keys [msg-payload put-fn]}]
-  (let [path (:directory msg-payload)]
-    (info "import-images:" path)
-    (ii/import-image-files path put-fn)
-    (ai/import-audio-files path put-fn)))
+(def data-path (:data-path rt/runtime-info))
+(def cfg-path (str data-path "/flutter-import-cfg.edn"))
+
+(defn read-cfg []
+  (when (existsSync cfg-path)
+    (read-string (readFileSync cfg-path "utf-8"))))
+
+(defn write-cfg [cfg]
+  (writeFileSync cfg-path (pr-str cfg)))
+
+(defn import-media [{:keys [put-fn]}]
+  (let [cfg (read-cfg)
+        path (:container-documents-path cfg)]
+    (when-not cfg (error "Flutter config does not exist"))
+    (when cfg
+      (info "import-images:" path)
+      (ii/import-image-files path put-fn)
+      (ai/import-audio-files path put-fn))))
+
+(defn set-flutter-docs-path [{:keys [msg-payload put-fn]}]
+  (let [path (:directory msg-payload)
+        cfg {:container-documents-path path}]
+    (info "writing flutter config")
+    (write-cfg cfg)))
 
 (defn cmp-map [cmp-id audio-path img-path]
   (reset! ai/audio-path-atom audio-path)
   (reset! ii/image-path-atom img-path)
   {:cmp-id      cmp-id
-   :handler-map {:import/health hi/import-health
-                 :import/media  import-media}})
+   :handler-map {:import/health                hi/import-health
+                 :import/set-flutter-docs-path set-flutter-docs-path
+                 :import/media                 import-media}})

--- a/src/cljs/meins/electron/main/menu.cljs
+++ b/src/cljs/meins/electron/main/menu.cljs
@@ -60,11 +60,11 @@
                      (put-fn [:import/photos files])))]
     (.showOpenDialog dialog options callback)))
 
-(defn import-media-dialog [put-fn]
+(defn flutter-path-dialog [put-fn]
   (let [options (clj->js {:properties  ["openDirectory"]
-                          :buttonLabel "Import Documents"})
+                          :buttonLabel "Select Container Documents Path"})
         selected-dir (first (js->clj (.showOpenDialogSync dialog options)))]
-    (put-fn [:import/media {:directory selected-dir}])))
+    (put-fn [:import/set-flutter-docs-path {:directory selected-dir}])))
 
 (defn import-health-dialog [put-fn]
   (let [options (clj->js {:properties  ["openFile" "multiSelections"]
@@ -123,8 +123,10 @@
                 :submenu [{:label       "Photos"
                            :accelerator "CmdOrCtrl+I"
                            :click       #(import-dialog put-fn)}
+                          {:label "Set Flutter Documents Path"
+                           :click #(flutter-path-dialog put-fn)}
                           {:label "Media from Flutter app"
-                           :click #(import-media-dialog put-fn)}
+                           :click #(put-fn [:import/media])}
                           {:label "Health Data from Flutter app"
                            :click #(import-health-dialog put-fn)}
                           (when (contains? capabilities :git-import)


### PR DESCRIPTION
This PR improves the UX when importing media entries from the flutter desktop version into meins (the ClojureScript desktop version) by setting the documents folder in the application container once, and then going forward allow importing with a single click in the menu, instead of having to find the respective folder time and again.