### PR TITLE
Questionnaires

### DIFF
--- a/wisely/lib/main.dart
+++ b/wisely/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:keyboard_dismisser/keyboard_dismisser.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -22,6 +23,7 @@ import 'package:wisely/pages/audio.dart';
 import 'package:wisely/pages/editor.dart';
 import 'package:wisely/pages/health_page.dart';
 import 'package:wisely/pages/journal_page.dart';
+import 'package:wisely/pages/linear_survey_page.dart';
 import 'package:wisely/pages/photo_import.dart';
 import 'package:wisely/pages/settings.dart';
 import 'package:wisely/theme.dart';
@@ -176,6 +178,7 @@ class _WiselyHomePageState extends State<WiselyHomePage> {
     PhotoImportPage(),
     AudioPage(),
     HealthPage(),
+    LinearSurveyPage(),
     SettingsPage(),
   ];
 
@@ -238,6 +241,10 @@ class _WiselyHomePageState extends State<WiselyHomePage> {
             BottomNavigationBarItem(
               icon: Icon(Icons.directions_run),
               label: 'Health',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(MdiIcons.clipboardOutline),
+              label: 'Surveys',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.settings),

--- a/wisely/lib/pages/linear_survey_page.dart
+++ b/wisely/lib/pages/linear_survey_page.dart
@@ -1,0 +1,47 @@
+// modified from https://github.com/cph-cachet/research.package/blob/master/example/lib/linear_survey_page.dart
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:research_package/research_package.dart';
+import 'package:wisely/surveys/linear_survey_objects.dart';
+
+class LinearSurveyPage extends StatelessWidget {
+  const LinearSurveyPage({Key? key}) : super(key: key);
+
+  String _encode(Object object) =>
+      const JsonEncoder.withIndent(' ').convert(object);
+
+  void printWrapped(String text) {
+    final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
+    pattern.allMatches(text).forEach((match) => debugPrint(match.group(0)));
+  }
+
+  void resultCallback(RPTaskResult result) {
+    // Do anything with the result
+    debugPrint(_encode(result));
+  }
+
+  void cancelCallBack(RPTaskResult result) {
+    // Do anything with the result at the moment of the cancellation
+    debugPrint("The result so far:\n" + _encode(result));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Expanded(
+        child: RPUITask(
+          task: linearSurveyTask,
+          onSubmit: resultCallback,
+          onCancel: (RPTaskResult? result) {
+            if (result == null) {
+              debugPrint("No result");
+            } else {
+              cancelCallBack(result);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/wisely/lib/surveys/linear_survey_objects.dart
+++ b/wisely/lib/surveys/linear_survey_objects.dart
@@ -1,0 +1,101 @@
+import 'package:research_package/model.dart';
+
+List<RPChoice> cqf11Choices = [
+  RPChoice(text: '0—Better than usual', value: 0),
+  RPChoice(text: '1—No worse than usual', value: 1),
+  RPChoice(text: '2—Worse than usual', value: 2),
+  RPChoice(text: '3—Much worse than usual', value: 3),
+];
+
+RPChoiceAnswerFormat cfq11AnswerFormat = RPChoiceAnswerFormat(
+  answerStyle: RPChoiceAnswerStyle.SingleChoice,
+  choices: cqf11Choices,
+);
+
+RPCompletionStep completionStep = RPCompletionStep(
+    identifier: 'completionID',
+    title: 'Finished',
+    text: 'Thank you for filling out the CFQ11!');
+
+RPInstructionStep instructionStep = RPInstructionStep(
+  identifier: 'cfq11Instructions',
+  title: 'Welcome!',
+  text: ' Chalder Fatigue Scale (CFQ 11)',
+  detailText:
+      'We would like to know more about any problems you have had with feeling '
+      'tired, weak or lacking in energy in the last month. Please answer ALL '
+      'the questions by ticking the answer which applies to you most closely. '
+      'If you have been feeling tired for a long while, then compare yourself '
+      'to how you felt when you were last well. Please tick only one box per'
+      ' line.\n\n'
+      '0—Better than usual, \n1—No worse than usual, \n2—Worse than usual, '
+      '\n3—Much worse than usual\n\n'
+      'Cella, M. and T. Chalder (2010). "Measuring fatigue in clinical and '
+      'community settings." J Psychosom Res 69(1): 17-22.',
+  footnote:
+      'Cella, M. and T. Chalder (2010). "Measuring fatigue in clinical and '
+      'community settings." J Psychosom Res 69(1): 17-22.',
+);
+
+RPOrderedTask linearSurveyTask = RPOrderedTask(
+  identifier: 'surveyTaskID',
+  steps: [
+    instructionStep,
+    RPQuestionStep(
+      identifier: 'cfq11Step1',
+      title: 'Do you have problems with tiredness?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step2',
+      title: 'Do you need to rest more?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step3',
+      title: 'Do you feel sleepy or drowsy?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step4',
+      title: 'Do you have problems starting things?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step5',
+      title: 'Do you lack energy?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step6',
+      title: 'Do you have less strength in your muscles?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step7',
+      title: 'Do you feel weak?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step8',
+      title: 'Do you have difficulty concentrating?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step9',
+      title: 'Do you make slips of the tongue when speaking?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step10',
+      title: 'Do you find it more difficult to find the right word?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    RPQuestionStep(
+      identifier: 'cfq11Step11',
+      title: 'How is your memory?',
+      answerFormat: cfq11AnswerFormat,
+    ),
+    completionStep
+  ],
+);

--- a/wisely/pubspec.lock
+++ b/wisely/pubspec.lock
@@ -176,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  carp_core:
+    dependency: transitive
+    description:
+      name: carp_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.31.3+1"
   characters:
     dependency: transitive
     description:
@@ -793,6 +800,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.0"
+  html_unescape:
+    dependency: transitive
+    description:
+      name: html_unescape
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:
@@ -1325,6 +1339,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  research_package:
+    dependency: "direct main"
+    description:
+      name: research_package
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.7"
   rxdart:
     dependency: transitive
     description:
@@ -1381,6 +1402,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  signature:
+    dependency: transitive
+    description:
+      name: signature
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.1"
+  simple_html_css:
+    dependency: transitive
+    description:
+      name: simple_html_css
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1+1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/wisely/pubspec.lock
+++ b/wisely/pubspec.lock
@@ -1017,6 +1017,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.10"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.6295"
   meta:
     dependency: transitive
     description:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.78+97
+version: 0.1.79+99
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -62,6 +62,7 @@ dependencies:
   wechat_assets_picker: ^6.2.2
   yaml: ^3.1.0
   research_package: ^0.6.7
+  material_design_icons_flutter: ^5.0.6295
 
 dev_dependencies:
   flutter_test:

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   uuid: ^3.0.4
   wechat_assets_picker: ^6.2.2
   yaml: ^3.1.0
+  research_package: ^0.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds the [`research_package`](https://github.com/cph-cachet/research.package) library for building surveys/questionnaires. In this first step, there's a page with the CFQ11 as one example, but results are not handled yet. Also, page by page is a bit cumbersome to use, it takes too long to navigate from page to page. Subsequent PRs will improve the UX, and deal with persisting results.