### PR TITLE
Custom editor toolbar

### DIFF
--- a/wisely/lib/widgets/buttons.dart
+++ b/wisely/lib/widgets/buttons.dart
@@ -24,7 +24,7 @@ class Button extends StatelessWidget {
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
           padding: const EdgeInsets.symmetric(
-            vertical: 16.0,
+            vertical: 8.0,
             horizontal: 32.0,
           ),
           primary: primaryColor,

--- a/wisely/lib/widgets/editor_toolbar.dart
+++ b/wisely/lib/widgets/editor_toolbar.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+
+class ToolbarWidget extends StatelessWidget {
+  const ToolbarWidget({
+    Key? key,
+    required QuillController controller,
+    double toolbarIconSize = 18.0,
+    required Function saveFn,
+    this.iconTheme,
+  })  : _controller = controller,
+        _saveFn = saveFn,
+        _toolbarIconSize = toolbarIconSize,
+        super(key: key);
+
+  final QuillController _controller;
+  final double _toolbarIconSize;
+  final Function _saveFn;
+  final WrapAlignment toolbarIconAlignment = WrapAlignment.start;
+  final QuillIconTheme? iconTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return QuillToolbar(
+      key: key,
+      toolbarHeight: _toolbarIconSize * 2,
+      toolbarSectionSpacing: 4,
+      toolbarIconAlignment: toolbarIconAlignment,
+      multiRowsDisplay: false,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.save),
+          iconSize: _toolbarIconSize,
+          tooltip: 'Save',
+          onPressed: () => _saveFn(),
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.bold,
+          icon: Icons.format_bold,
+          iconSize: _toolbarIconSize,
+          controller: _controller,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.italic,
+          icon: Icons.format_italic,
+          iconSize: _toolbarIconSize,
+          controller: _controller,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.underline,
+          icon: Icons.format_underline,
+          iconSize: _toolbarIconSize,
+          controller: _controller,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.inlineCode,
+          icon: Icons.code,
+          iconSize: _toolbarIconSize,
+          controller: _controller,
+          iconTheme: iconTheme,
+        ),
+        ClearFormatButton(
+          icon: Icons.format_clear,
+          iconSize: _toolbarIconSize,
+          controller: _controller,
+          iconTheme: iconTheme,
+        ),
+        SelectHeaderStyleButton(
+          controller: _controller,
+          iconSize: _toolbarIconSize,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.ol,
+          controller: _controller,
+          icon: Icons.format_list_numbered,
+          iconSize: _toolbarIconSize,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.ul,
+          controller: _controller,
+          icon: Icons.format_list_bulleted,
+          iconSize: _toolbarIconSize,
+          iconTheme: iconTheme,
+        ),
+        ToggleStyleButton(
+          attribute: Attribute.codeBlock,
+          controller: _controller,
+          icon: Icons.code,
+          iconSize: _toolbarIconSize,
+          iconTheme: iconTheme,
+        ),
+      ],
+    );
+  }
+}

--- a/wisely/lib/widgets/editor_toolbar.dart
+++ b/wisely/lib/widgets/editor_toolbar.dart
@@ -5,7 +5,7 @@ class ToolbarWidget extends StatelessWidget {
   const ToolbarWidget({
     Key? key,
     required QuillController controller,
-    double toolbarIconSize = 18.0,
+    double toolbarIconSize = 24.0,
     required Function saveFn,
     this.iconTheme,
   })  : _controller = controller,

--- a/wisely/lib/widgets/editor_widget.dart
+++ b/wisely/lib/widgets/editor_widget.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:wisely/theme.dart';
+import 'package:wisely/widgets/editor_toolbar.dart';
 
 class EditorWidget extends StatelessWidget {
   const EditorWidget({
@@ -58,44 +58,16 @@ class EditorWidget extends StatelessWidget {
         color: AppColors.editorBgColor,
         child: Column(
           children: [
-            Container(
-              color: Colors.grey[100],
-              width: double.maxFinite,
-              child: Wrap(
-                //mainAxisAlignment: MainAxisAlignment.center,
-                //crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.save),
-                    iconSize: 20,
-                    tooltip: 'Save',
-                    onPressed: () => _saveFn(),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 3.0),
-                    child: QuillToolbar.basic(
-                      controller: _controller,
-                      showColorButton: false,
-                      showBackgroundColorButton: false,
-                      showListCheck: false,
-                      showIndent: false,
-                      showQuote: false,
-                      showSmallButton: false,
-                      showImageButton: false,
-                      showLink: false,
-                      showUnderLineButton: false,
-                      showAlignmentButtons: false,
-                    ),
-                  ),
-                ],
-              ),
+            ToolbarWidget(
+              controller: _controller,
+              saveFn: _saveFn,
             ),
             Expanded(
               child: Padding(
                 padding: EdgeInsets.symmetric(horizontal: _padding),
                 child: QuillEditor.basic(
                   controller: _controller,
-                  readOnly: _readOnly, // true for view only mode
+                  readOnly: _readOnly,
                 ),
               ),
             )

--- a/wisely/lib/widgets/editor_widget.dart
+++ b/wisely/lib/widgets/editor_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:wisely/theme.dart';
@@ -58,9 +60,12 @@ class EditorWidget extends StatelessWidget {
         color: AppColors.editorBgColor,
         child: Column(
           children: [
-            ToolbarWidget(
-              controller: _controller,
-              saveFn: _saveFn,
+            Visibility(
+              visible: Platform.isMacOS,
+              child: ToolbarWidget(
+                controller: _controller,
+                saveFn: _saveFn,
+              ),
             ),
             Expanded(
               child: Padding(
@@ -70,7 +75,14 @@ class EditorWidget extends StatelessWidget {
                   readOnly: _readOnly,
                 ),
               ),
-            )
+            ),
+            Visibility(
+              visible: Platform.isIOS || Platform.isAndroid,
+              child: ToolbarWidget(
+                controller: _controller,
+                saveFn: _saveFn,
+              ),
+            ),
           ],
         ),
       ),

--- a/wisely/lib/widgets/entry_modal_widget.dart
+++ b/wisely/lib/widgets/entry_modal_widget.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:delta_markdown/delta_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:provider/src/provider.dart';
 import 'package:wisely/blocs/journal/persistence_cubit.dart';
 import 'package:wisely/classes/entry_text.dart';
@@ -48,6 +48,30 @@ class EntryModalWidget extends StatelessWidget {
               geolocation: entry.geolocation,
             ),
             orElse: () => Container(),
+          ),
+          Center(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      vertical: 4.0, horizontal: 16.0),
+                  child: Text(
+                    df.format(item.meta.dateFrom),
+                    style: const TextStyle(
+                      fontFamily: 'Oswald',
+                      fontSize: 18.0,
+                      fontWeight: FontWeight.w300,
+                    ),
+                  ),
+                ),
+                Button(
+                  'Close',
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
           ),
           item.maybeMap(
             journalAudio: (JournalAudio audio) {
@@ -118,23 +142,6 @@ class EntryModalWidget extends StatelessWidget {
               ),
             ),
             orElse: () => Container(),
-          ),
-          Padding(
-            padding:
-                const EdgeInsets.symmetric(vertical: 4.0, horizontal: 16.0),
-            child: InfoText(df.format(item.meta.dateFrom)),
-          ),
-          Center(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Button(
-                  'Close',
-                  onPressed: () => Navigator.pop(context),
-                  padding: const EdgeInsets.only(bottom: 16.0, right: 16.0),
-                ),
-              ],
-            ),
           ),
         ],
       ),

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wisely
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.80+106
+version: 0.1.81+107
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes the use of the `QuillToolbar.basic` and instead adds a custom toolbar, which will be more flexible going forward. This also fixes the issue with the line break between toolbar and the save button. Also, the toolbar is moved directly above the keyboard on mobile.