### PR TITLE
rename PRODUCT_BUNDLE_IDENTIFIER in iOS and macOS

### DIFF
--- a/lotti/ios/Flutter/Base.xcconfig
+++ b/lotti/ios/Flutter/Base.xcconfig
@@ -1,4 +1,4 @@
 #include "Generated.xcconfig"
 
 APP_NAME=Lotti
-PRODUCT_BUNDLE_IDENTIFIER=com.matthiasnehlsen.wiselyMobile
+PRODUCT_BUNDLE_IDENTIFIER=com.matthiasnehlsen.lotti.mobile

--- a/lotti/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/lotti/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "wisely.app"
+               BuildableName = "Lotti.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "wisely.app"
+            BuildableName = "Lotti.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -54,7 +54,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "wisely.app"
+            BuildableName = "Lotti.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -71,7 +71,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "wisely.app"
+            BuildableName = "Lotti.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/lotti/macos/Runner/Configs/AppInfo.xcconfig
+++ b/lotti/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = Lotti
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.matthiasnehlsen.wisely
+PRODUCT_BUNDLE_IDENTIFIER = com.matthiasnehlsen.lotti.desktop
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2021 Mathias Nehlsen. All rights reserved.

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.1.89+122
+version: 0.2.1+122
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR concludes the renaming effort.