### PR TITLE
postpone encryption, enqueue unencrypted

### DIFF
--- a/lotti/assets/sqlite/create_outbound_db.sql
+++ b/lotti/assets/sqlite/create_outbound_db.sql
@@ -5,6 +5,6 @@ CREATE TABLE "outbound" (
   "retries" INTEGER NOT NULL,
   "updated_at" INTEGER,
   "message" TEXT NOT NULL,
-  "encrypted_file_path" TEXT,
+  "file_path" TEXT,
   "subject" TEXT NOT NULL
 );

--- a/lotti/lib/blocs/sync/imap/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_cubit.dart
@@ -9,7 +9,6 @@ import 'package:lotti/blocs/sync/encryption_cubit.dart';
 import 'package:lotti/blocs/sync/imap/imap_client.dart';
 import 'package:lotti/blocs/sync/imap/imap_state.dart';
 import 'package:lotti/blocs/sync/imap/outbox_save_imap.dart';
-import 'package:lotti/utils/image_utils.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class OutboxImapCubit extends Cubit<ImapState> {
@@ -25,9 +24,9 @@ class OutboxImapCubit extends Cubit<ImapState> {
     _encryptionCubit = encryptionCubit;
   }
 
-  Future<bool> saveImap(
-    String encryptedMessage,
-    String subject, {
+  Future<bool> saveImap({
+    required String encryptedMessage,
+    required String subject,
     String? encryptedFilePath,
   }) async {
     ImapClient? imapClient;
@@ -38,7 +37,7 @@ class OutboxImapCubit extends Cubit<ImapState> {
       GenericImapResult? res;
       if (imapClient != null) {
         if (encryptedFilePath != null && encryptedFilePath.isNotEmpty) {
-          File encryptedFile = File(await getFullAssetPath(encryptedFilePath));
+          File encryptedFile = File(encryptedFilePath);
           int fileLength = encryptedFile.lengthSync();
           if (fileLength > 0) {
             res = await saveImapMessage(imapClient, subject, encryptedMessage,

--- a/lotti/lib/blocs/sync/outbound_queue_db.dart
+++ b/lotti/lib/blocs/sync/outbound_queue_db.dart
@@ -50,18 +50,18 @@ class OutboundQueueDb {
     await _database;
   }
 
-  Future<void> queueInsert(
-    String encryptedMessage,
-    String subject, {
-    String? encryptedFilePath,
+  Future<void> queueInsert({
+    required String message,
+    required String subject,
+    String? filePath,
   }) async {
     final transaction = Sentry.startTransaction('insert()', 'task');
     try {
       final db = await _database;
 
       OutboundQueueRecord dbRecord = OutboundQueueRecord(
-        encryptedMessage: encryptedMessage,
-        encryptedFilePath: getRelativeAssetPath(encryptedFilePath),
+        message: message,
+        filePath: getRelativeAssetPath(filePath),
         subject: subject,
         status: OutboundMessageStatus.pending,
         retries: 0,
@@ -91,13 +91,13 @@ class OutboundQueueDb {
 
       OutboundQueueRecord dbRecord = OutboundQueueRecord(
         id: prev.id,
-        encryptedMessage: prev.encryptedMessage,
+        message: prev.message,
         subject: prev.subject,
         status: status,
         retries: retries,
         createdAt: prev.createdAt,
         updatedAt: DateTime.now(),
-        encryptedFilePath: prev.encryptedFilePath,
+        filePath: prev.filePath,
       );
 
       await db.insert(

--- a/lotti/lib/blocs/sync/outbound_queue_state.dart
+++ b/lotti/lib/blocs/sync/outbound_queue_state.dart
@@ -14,22 +14,22 @@ enum OutboundMessageStatus { pending, sent, error }
 
 class OutboundQueueRecord {
   final int? id;
-  final String encryptedMessage;
+  final String message;
   final OutboundMessageStatus status;
   final int retries;
   final String subject;
-  final String? encryptedFilePath;
+  final String? filePath;
   final DateTime createdAt;
   DateTime? updatedAt;
 
   OutboundQueueRecord({
     this.id,
-    required this.encryptedMessage,
+    required this.message,
     required this.subject,
     required this.status,
     required this.retries,
     required this.createdAt,
-    this.encryptedFilePath,
+    this.filePath,
     this.updatedAt,
   });
 
@@ -41,8 +41,8 @@ class OutboundQueueRecord {
   factory OutboundQueueRecord.fromMap(Map<String, dynamic> data) =>
       OutboundQueueRecord(
         id: data['id'],
-        encryptedMessage: data['message'],
-        encryptedFilePath: data['encrypted_file_path'],
+        message: data['message'],
+        filePath: data['file_path'],
         status: OutboundMessageStatus.values[data['status']],
         retries: data['retries'],
         subject: data['subject'],
@@ -57,8 +57,8 @@ class OutboundQueueRecord {
       'updated_at': updatedAt?.millisecondsSinceEpoch,
       'status': status.index,
       'retries': retries,
-      'message': encryptedMessage,
-      'encrypted_file_path': encryptedFilePath,
+      'message': message,
+      'file_path': filePath,
       'subject': subject,
     };
   }

--- a/lotti/lib/sync/encryption.dart
+++ b/lotti/lib/sync/encryption.dart
@@ -11,7 +11,7 @@ FutureOr<void> encryptFileIsolate(EncryptFileMessage msg) async {
   final transaction = Sentry.startTransaction('encryptFile()', 'task');
 
   if (!msg.inputFile.existsSync()) {
-    debugPrint('File does not exist, aborting');
+    debugPrint('File ${msg.inputFile} does not exist, aborting');
     throw Exception("File not found");
   }
 
@@ -94,7 +94,10 @@ Future<String> encryptStringIsolate(EncryptStringMessage msg) async {
   return base64.encode(secretBox.concatenation());
 }
 
-Future<String> encryptString(String plainText, b64Secret) async {
+Future<String> encryptString({
+  required String plainText,
+  required b64Secret,
+}) async {
   return compute(
     encryptStringIsolate,
     EncryptStringMessage(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.2.1+122
+version: 0.2.2+123
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/test/encryption_string_test.dart
+++ b/lotti/test/encryption_string_test.dart
@@ -10,7 +10,10 @@ void main() {
     final originalFile = File('test_resources/test.txt');
     String testString = await originalFile.readAsString();
     final String b64Secret = Key.fromSecureRandom(32).base64;
-    final String encryptedMessage = await encryptString(testString, b64Secret);
+    final String encryptedMessage = await encryptString(
+      b64Secret: b64Secret,
+      plainText: testString,
+    );
     final String decrypted = await decryptString(encryptedMessage, b64Secret);
     debugPrint('AES GCM decrypted: $decrypted');
     expect(decrypted, testString);


### PR DESCRIPTION
This PR changes the outbound queue to store plain text messages, and also postpone the file encryption to when the message will be sent. Thus, items can be inserted with a lot less CPU load, and will later only cause CPU load for one entry at a time. In terms of security, this does not make a difference, as `outbound.db` and `journal.db` enjoy the same level of protection. In case SQLite databases in this app will be encrypted, these two database files need to be treated the same way.