### PR TITLE
create new entry from update message when not existing

### DIFF
--- a/lotti/lib/blocs/journal/persistence_db.dart
+++ b/lotti/lib/blocs/journal/persistence_db.dart
@@ -113,10 +113,16 @@ class PersistenceDb {
       final db = await _database;
       JournalRecord dbRecord = _journalEntityToDbRecord(journalEntity);
       String id = dbRecord.id;
-      var res = await db.update(journalTable, dbRecord.toMap(),
-          where: 'id = ?', whereArgs: [id]);
 
-      debugPrint('PersistenceDb updated: $id $res');
+      List<Map> maps = await db.query(journalTable,
+          columns: ['id'], where: 'id = ?', whereArgs: [id]);
+      if (maps.isEmpty) {
+        insert(journalEntity);
+      } else {
+        int res = await db.update(journalTable, dbRecord.toMap(),
+            where: 'id = ?', whereArgs: [id]);
+        debugPrint('PersistenceDb updated: $id $res');
+      }
       return true;
     } catch (exception, stackTrace) {
       await Sentry.captureException(exception, stackTrace: stackTrace);

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.2.3+125
+version: 0.2.4+126
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a check in the entry persistence from sync if entry to update actually exists. If not, it is created. This ensures that entries are created e.g. when previous create messages got lost in the sync mailbox, for whatever reasons, such as space limitations.