### PR TITLE
basic drift database with conflicts table

### DIFF
--- a/lotti/ios/Podfile.lock
+++ b/lotti/ios/Podfile.lock
@@ -89,6 +89,24 @@ PODS:
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
+  - sqlite3 (3.36.0):
+    - sqlite3/common (= 3.36.0)
+  - sqlite3/common (3.36.0)
+  - sqlite3/fts5 (3.36.0):
+    - sqlite3/common
+  - sqlite3/json1 (3.36.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.36.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.36.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - sqlite3 (~> 3.36.0)
+    - sqlite3/fts5
+    - sqlite3/json1
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
   - url_launcher (0.0.1):
     - Flutter
   - video_player (0.0.1):
@@ -118,6 +136,7 @@ DEPENDENCIES:
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
   - video_player (from `.symlinks/plugins/video_player/ios`)
 
@@ -134,6 +153,7 @@ SPEC REPOS:
     - SDWebImage
     - SDWebImageWebPCoder
     - Sentry
+    - sqlite3
 
 EXTERNAL SOURCES:
   audio_session:
@@ -182,6 +202,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sentry_flutter/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  sqlite3_flutter_libs:
+    :path: ".symlinks/plugins/sqlite3_flutter_libs/ios"
   url_launcher:
     :path: ".symlinks/plugins/url_launcher/ios"
   video_player:
@@ -222,6 +244,8 @@ SPEC CHECKSUMS:
   Sentry: 0718c3ad7a08e1107599610795adaf08864102f3
   sentry_flutter: 4cd99764f9fe01c9415790d1f3fb1c7fd3a5cbe9
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+  sqlite3: 797b1b1f92baf74716a3179f69d9652ce4a5df3f
+  sqlite3_flutter_libs: a1d040d0c9b60435b50e9626a9e818ddff842487
   url_launcher: b6e016d912f04be9f5bf6e8e82dc599b7ba59649
   video_player: ecd305f42e9044793efd34846e1ce64c31ea6fcb
 

--- a/lotti/lib/drift_db/database.dart
+++ b/lotti/lib/drift_db/database.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'database.g.dart';
+
+class Conflicts extends Table {
+  TextColumn get id => text()();
+  DateTimeColumn get createdAt => dateTime().named('created_at')();
+  DateTimeColumn get updatedAt => dateTime().named('updated_at')();
+  TextColumn get serialized => text()();
+  IntColumn get status => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, 'drift.sqlite'));
+    return NativeDatabase(file);
+  });
+}
+
+@DriftDatabase(tables: [Conflicts])
+class MyDriftDatabase extends _$MyDriftDatabase {
+  MyDriftDatabase() : super(_openConnection());
+
+  Future<int> addConflict(Conflict conflict) {
+    return into(conflicts).insert(conflict);
+  }
+
+  @override
+  int get schemaVersion => 1;
+}

--- a/lotti/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/lotti/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -17,6 +17,7 @@ import path_provider_macos
 import photo_manager
 import sentry_flutter
 import sqflite
+import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -32,5 +33,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ImageScannerPlugin.register(with: registry.registrar(forPlugin: "ImageScannerPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/lotti/macos/Podfile.lock
+++ b/lotti/macos/Podfile.lock
@@ -36,6 +36,24 @@ PODS:
   - sqflite (0.0.2):
     - FlutterMacOS
     - FMDB (>= 2.7.5)
+  - sqlite3 (3.36.0):
+    - sqlite3/common (= 3.36.0)
+  - sqlite3/common (3.36.0)
+  - sqlite3/fts5 (3.36.0):
+    - sqlite3/common
+  - sqlite3/json1 (3.36.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.36.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.36.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - FlutterMacOS
+    - sqlite3 (~> 3.36.0)
+    - sqlite3/fts5
+    - sqlite3/json1
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
 
@@ -53,6 +71,7 @@ DEPENDENCIES:
   - photo_manager (from `Flutter/ephemeral/.symlinks/plugins/photo_manager/macos`)
   - sentry_flutter (from `Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos`)
   - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/macos`)
+  - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 SPEC REPOS:
@@ -60,6 +79,7 @@ SPEC REPOS:
     - FMDB
     - ReachabilitySwift
     - Sentry
+    - sqlite3
 
 EXTERNAL SOURCES:
   audio_session:
@@ -88,6 +108,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos
   sqflite:
     :path: Flutter/ephemeral/.symlinks/plugins/sqflite/macos
+  sqlite3_flutter_libs:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
@@ -108,6 +130,8 @@ SPEC CHECKSUMS:
   Sentry: 0718c3ad7a08e1107599610795adaf08864102f3
   sentry_flutter: 4cd99764f9fe01c9415790d1f3fb1c7fd3a5cbe9
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
+  sqlite3: 797b1b1f92baf74716a3179f69d9652ce4a5df3f
+  sqlite3_flutter_libs: 88d67935d0135be061e7e310732a1ce6f204c446
   url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
 
 PODFILE CHECKSUM: 8d40c19d3cbdb380d870685c3a564c989f1efa52

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -407,6 +407,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.1"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   encrypt:
     dependency: transitive
     description:
@@ -1472,6 +1486,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1+1"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.0"
   stack_trace:
     dependency: transitive
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.2.4+126
+version: 0.2.5+127
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -65,12 +65,15 @@ dependencies:
   uuid: ^3.0.4
   wechat_assets_picker: ^6.2.2
   yaml: ^3.1.0
+  drift: ^1.0.1
+  sqlite3_flutter_libs: ^0.5.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.1.4
   dart_code_metrics: ^4.6.0
+  drift_dev: ^1.0.2
   flutter_lints: ^1.0.0
   flutter_native_splash: ^1.3.1
   freezed: ^1.0.0


### PR DESCRIPTION
This PR lays the foundation for checking and persisting conflicts (until manual resolution by the user). Drift is used as the ORM - it is getting too tedious to write the database mappers by hand. Also it is very attractive to benefit from more comprehensive compile time checks. Not functional yet, but merging anyway as the Drift foundation will be useful elsewhere.