### PR TITLE
refactor & upsert

### DIFF
--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/classes/journal_entities.dart';
+
+import 'database.dart';
+
+JournalDbEntity toDbEntity(JournalEntity journalEntity) {
+  final DateTime createdAt = journalEntity.meta.createdAt;
+  final subtype = journalEntity.maybeMap(
+    quantitative: (qd) => qd.data.dataType,
+    survey: (SurveyEntry surveyEntry) => surveyEntry.data.taskResult.identifier,
+    orElse: () => '',
+  );
+
+  Geolocation? geolocation;
+  journalEntity.mapOrNull(
+    journalAudio: (item) => geolocation = item.geolocation,
+    journalImage: (item) => geolocation = item.geolocation,
+    journalEntry: (item) => geolocation = item.geolocation,
+  );
+
+  String id = journalEntity.meta.id;
+  JournalDbEntity dbEntity = JournalDbEntity(
+    id: id,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+    dateFrom: journalEntity.meta.dateFrom,
+    dateTo: journalEntity.meta.dateTo,
+    type: journalEntity.runtimeType.toString(),
+    subtype: subtype,
+    serialized: json.encode(journalEntity),
+    schemaVersion: 0,
+    longitude: geolocation?.longitude,
+    latitude: geolocation?.latitude,
+    geohashString: geolocation?.geohashString,
+  );
+
+  return dbEntity;
+}
+
+JournalEntity fromDbEntity(JournalDbEntity dbEntity) {
+  return JournalEntity.fromJson(json.decode(dbEntity.serialized));
+}

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.2.9+146
+version: 0.2.10+147
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes the database layer to use an `upsert` instead of separate `insert` and `update` functions, which is simpler and viable since the update is also operating with the entire entity, instead of updating just a few fields.