### PR TITLE
Only import measurement when defined in mapping file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.364",
+  "version": "0.6.365",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.364",
+  "version": "0.6.365",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/import/measurement.cljs
+++ b/src/cljs/meins/electron/main/import/measurement.cljs
@@ -34,7 +34,8 @@
                :longitude        (get geolocation "longitude")
                :latitude         (get geolocation "latitude")
                :vclock           (get meta-data "vectorClock")}]
-    entry))
+    (when measurement-key
+      entry)))
 
 (defn import-measurement-entries [path data-path put-fn]
   (let [files (sync (str path "/measurement/**/*.measurement.json"))]


### PR DESCRIPTION
This PR prevents measurement entries from being imported without value.