### PR TITLE
Fix parsing numbers with comma as decimal separator

### DIFF
--- a/lotti/lib/widgets/journal/entry_tools.dart
+++ b/lotti/lib/widgets/journal/entry_tools.dart
@@ -3,7 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 
-NumberFormat nf = NumberFormat("###.0#", "en_US");
+NumberFormat nf = NumberFormat('###.##');
 DateFormat df = DateFormat('yyyy-MM-dd HH:mm:ss');
 
 String formatType(String s) => s.replaceAll('HealthDataType.', '');

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -65,7 +65,8 @@ class JournalCardTitle extends StatelessWidget {
                     SurveySummaryWidget(surveyEntry),
                 measurement: (MeasurementEntry measurementEntry) {
                   MeasurementData data = measurementEntry.data;
-                  return EntryText('${data.dataType.displayName}: ${data.value}'
+                  return EntryText(
+                      '${data.dataType.displayName}: ${nf.format(data.value)}'
                       '\n${measurementEntry.entryText?.plainText ?? ''}');
                 },
                 orElse: () => Row(

--- a/lotti/lib/widgets/pages/add/new_measurement_page.dart
+++ b/lotti/lib/widgets/pages/add/new_measurement_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/measurables.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/main.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
 
 class NewMeasurementPage extends StatefulWidget {
   const NewMeasurementPage({Key? key}) : super(key: key);
@@ -60,7 +61,8 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                         dataType: formData!['type'] as MeasurableDataType,
                         dateTo: now,
                         dateFrom: now,
-                        value: double.parse(formData['value']),
+                        value: nf
+                            .parse('${formData['value']}'.replaceAll(',', '.')),
                       );
                       context
                           .read<PersistenceCubit>()

--- a/lotti/lib/widgets/pages/settings/measurables.dart
+++ b/lotti/lib/widgets/pages/settings/measurables.dart
@@ -196,7 +196,6 @@ class DetailRoute extends StatefulWidget {
 
 class _DetailRouteState extends State<DetailRoute> {
   final _formKey = GlobalKey<FormBuilderState>();
-  final JournalDb _db = getIt<JournalDb>();
 
   @override
   Widget build(BuildContext context) {

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.2.12+165
+version: 0.2.13+166
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes parsing decimal numbers e.g. for German locale where the comma is used as the decimal separator.