### PR TITLE
Finish saving photos before insert into database

### DIFF
--- a/lotti/lib/blocs/sync/imap/inbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_cubit.dart
@@ -88,7 +88,7 @@ class InboxImapCubit extends Cubit<ImapState> {
               (JournalEntity journalEntity, SyncEntryStatus status) async {
             await saveJournalEntityJson(journalEntity);
 
-            journalEntity.maybeMap(
+            await journalEntity.maybeMap(
               journalAudio: (JournalAudio journalAudio) async {
                 if (syncMessage.status == SyncEntryStatus.initial) {
                   await saveAudioAttachment(message, journalAudio, b64Secret);

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.4+172
+version: 0.3.5+173
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR addresses the issue that photo attachments were not saved yet when the insert into the database happened, leading to black squares instead of thumbnails in the journal. This is fixed by awaiting the file persistence before database insert.