### PR TITLE
Restart polling

### DIFF
--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -113,7 +113,7 @@ class OutboxCubit extends Cubit<OutboxState> {
 
         if (isConnected && !sendMutex.isLocked) {
           List<OutboxItem> unprocessed =
-              await _syncDatabase.oldestOutboxItems(1);
+              await _syncDatabase.oldestOutboxItems(10);
           if (unprocessed.isNotEmpty) {
             sendMutex.acquire();
 

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -47,6 +47,11 @@ class OutboxCubit extends Cubit<OutboxState> {
     Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
       _connectivityResult = result;
       debugPrint('Connectivity onConnectivityChanged $result');
+      if (result == ConnectivityResult.none) {
+        stopPolling();
+      } else {
+        startPolling();
+      }
     });
 
     if (!Platform.isMacOS) {
@@ -148,7 +153,7 @@ class OutboxCubit extends Cubit<OutboxState> {
                 if (unprocessed.length > 1) {
                   sendNext(imapClient: successfulClient);
                 }
-              } else {}
+              }
             } catch (e) {
               _syncDatabase.updateOutboxItem(
                 OutboxCompanion(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.9+181
+version: 0.3.9+182
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.8+180
+version: 0.3.9+181
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds restarting polling of the outbox queue when a network status change is detected and this status is anything other than `none`. Also, the pending messages query now fetches multiple results so that the client reuse path can be reached.