### PR TITLE
Conflict resolution

### DIFF
--- a/lotti/ios/Flutter/Debug.xcconfig
+++ b/lotti/ios/Flutter/Debug.xcconfig
@@ -3,4 +3,4 @@
 #include "Base.xcconfig"
 
 APP_NAME=$(inherited)Dev
-PRODUCT_BUNDLE_IDENTIFIER=$(inherited)Dev
+PRODUCT_BUNDLE_IDENTIFIER=$(inherited).dev

--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -354,17 +354,17 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     final transaction = Sentry.startTransaction('updateDbEntity()', 'task');
     try {
       int res = await _journalDb.updateJournalEntity(journalEntity);
-      bool saved = (res != 0);
+      debugPrint('updateDbEntity res $res');
       await saveJournalEntityJson(journalEntity);
 
-      if (saved && enqueueSync) {
+      if (enqueueSync) {
         await _outboundQueueCubit.enqueueMessage(SyncMessage.journalEntity(
           journalEntity: journalEntity,
           status: SyncEntryStatus.update,
         ));
       }
       await transaction.finish();
-      return saved;
+      return true;
     } catch (exception, stackTrace) {
       await Sentry.captureException(exception, stackTrace: stackTrace);
       debugPrint('Exception $exception');

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -81,6 +81,15 @@ class OutboxCubit extends Cubit<OutboxState> {
     startPolling();
   }
 
+  Future<void> toggleStatus() async {
+    if (state is OutboxDisabled) {
+      emit(OutboxState.online());
+      startPolling();
+    } else {
+      emit(OutboxState.disabled());
+    }
+  }
+
   void reportConnectivity() async {
     await Sentry.captureEvent(
         SentryEvent(
@@ -100,6 +109,8 @@ class OutboxCubit extends Cubit<OutboxState> {
   }
 
   void sendNext({ImapClient? imapClient}) async {
+    if (state is OutboxDisabled) return;
+
     final transaction = Sentry.startTransaction('sendNext()', 'task');
     try {
       _connectivityResult = await Connectivity().checkConnectivity();

--- a/lotti/lib/blocs/sync/outbox_state.dart
+++ b/lotti/lib/blocs/sync/outbox_state.dart
@@ -7,6 +7,7 @@ class OutboxState with _$OutboxState {
   factory OutboxState.initial() = _Initial;
   factory OutboxState.loading() = _Loading;
   factory OutboxState.online() = _Online;
+  factory OutboxState.disabled() = OutboxDisabled;
   factory OutboxState.failed() = _Failed;
 }
 

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -40,8 +40,12 @@ JournalDbEntity toDbEntity(JournalEntity journalEntity) {
   return dbEntity;
 }
 
+JournalEntity fromSerialized(String serialized) {
+  return JournalEntity.fromJson(json.decode(serialized));
+}
+
 JournalEntity fromDbEntity(JournalDbEntity dbEntity) {
-  return JournalEntity.fromJson(json.decode(dbEntity.serialized));
+  return fromSerialized(dbEntity.serialized);
 }
 
 MeasurableDataType measurableDataType(MeasurableDbEntity dbEntity) {

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -15,7 +15,7 @@ import 'conversions.dart';
 part 'database.g.dart';
 
 enum ConflictStatus {
-  unprocessed,
+  unresolved,
   resolved,
 }
 
@@ -66,7 +66,7 @@ class JournalDb extends _$JournalDb {
           updatedAt: now,
           serialized: jsonEncode(updated),
           schemaVersion: schemaVersion,
-          status: ConflictStatus.unprocessed.index,
+          status: ConflictStatus.unresolved.index,
         ));
       }
 
@@ -133,6 +133,11 @@ class JournalDb extends _$JournalDb {
     int limit = 1000,
   }) {
     return conflictsByStatus(status.index, limit).watch();
+  }
+
+  Future<int> resolveConflict(Conflict conflict) {
+    return (update(conflicts)..where((t) => t.id.equals(conflict.id)))
+        .write(conflict.copyWith(status: ConflictStatus.resolved.index));
   }
 
   Future<int> upsertEntityDefinition(EntityDefinition entityDefinition) async {

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -103,6 +103,13 @@ class JournalDb extends _$JournalDb {
     }
   }
 
+  Future<JournalEntity?> journalEntityById(String id) async {
+    JournalDbEntity? dbEntity = await entityById(id);
+    if (dbEntity != null) {
+      return fromDbEntity(dbEntity);
+    }
+  }
+
   List<JournalEntity> entityStreamMapper(List<JournalDbEntity> dbEntities) {
     return dbEntities.map((e) => fromDbEntity(e)).toList();
   }
@@ -119,6 +126,13 @@ class JournalDb extends _$JournalDb {
           ..orderBy([(t) => OrderingTerm(expression: t.uniqueName)]))
         .map(measurableDataType)
         .watch();
+  }
+
+  Stream<List<Conflict>> watchConflicts(
+    ConflictStatus status, {
+    int limit = 1000,
+  }) {
+    return conflictsByStatus(status.index, limit).watch();
   }
 
   Future<int> upsertEntityDefinition(EntityDefinition entityDefinition) async {

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -75,3 +75,9 @@ orderedJournal:
 SELECT * FROM journal
   ORDER BY date_from DESC
   LIMIT :limit;
+
+conflictsByStatus:
+SELECT * FROM conflicts
+  WHERE status = :status
+  ORDER BY created_at DESC
+  LIMIT :limit;

--- a/lotti/lib/sync/vector_clock.dart
+++ b/lotti/lib/sync/vector_clock.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 
 class VclockException implements Exception {
@@ -69,6 +71,27 @@ class VectorClock {
     }
 
     return VclockStatus.concurrent;
+  }
+
+  static VectorClock merge(VectorClock? vc1, VectorClock? vc2) {
+    Map<String, int> merged = <String, int>{};
+    Set<String> nodeIds = <String>{};
+
+    if (vc1?.vclock != null) {
+      nodeIds.addAll(vc1!.vclock.keys);
+    }
+    if (vc2?.vclock != null) {
+      nodeIds.addAll(vc2!.vclock.keys);
+    }
+
+    for (String nodeId in nodeIds) {
+      merged[nodeId] = max(
+        vc1?.get(nodeId) ?? 0,
+        vc2?.get(nodeId) ?? 0,
+      );
+    }
+
+    return VectorClock(merged);
   }
 
   int get(String node) {

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -61,7 +61,7 @@ class EditorWidget extends StatelessWidget {
         child: Column(
           children: [
             Visibility(
-              visible: Platform.isMacOS,
+              visible: Platform.isMacOS && !_readOnly,
               child: ToolbarWidget(
                 controller: _controller,
                 saveFn: _saveFn,
@@ -77,7 +77,7 @@ class EditorWidget extends StatelessWidget {
               ),
             ),
             Visibility(
-              visible: Platform.isIOS || Platform.isAndroid,
+              visible: (Platform.isIOS || Platform.isAndroid) && !_readOnly,
               child: ToolbarWidget(
                 controller: _controller,
                 saveFn: _saveFn,

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -44,12 +44,12 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: AppColors.entryBgColor,
+      color: AppColors.bodyBgColor,
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
       child: ListView(
-        shrinkWrap: false,
+        shrinkWrap: true,
         children: <Widget>[
           widget.item.maybeMap(
             journalAudio: (JournalAudio audio) {

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -5,7 +5,6 @@ import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/theme.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
@@ -18,9 +17,11 @@ import 'package:provider/src/provider.dart';
 
 class EntryDetailWidget extends StatefulWidget {
   final JournalEntity item;
+  final bool readOnly;
   const EntryDetailWidget({
     Key? key,
     required this.item,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -43,133 +44,125 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: AppColors.bodyBgColor,
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
-      child: ListView(
-        shrinkWrap: true,
-        children: <Widget>[
-          widget.item.maybeMap(
-            journalAudio: (JournalAudio audio) {
-              QuillController _controller =
-                  makeController(serializedQuill: audio.entryText?.quill);
+    return Column(
+      children: <Widget>[
+        widget.item.maybeMap(
+          journalAudio: (JournalAudio audio) {
+            QuillController _controller =
+                makeController(serializedQuill: audio.entryText?.quill);
 
-              void saveText() {
-                EntryText entryText = entryTextFromController(_controller);
+            void saveText() {
+              EntryText entryText = entryTextFromController(_controller);
 
-                context
-                    .read<PersistenceCubit>()
-                    .updateJournalEntity(widget.item, entryText);
-              }
+              context
+                  .read<PersistenceCubit>()
+                  .updateJournalEntity(widget.item, entryText);
+            }
 
-              return Column(
-                children: [
-                  EditorWidget(
-                    controller: _controller,
-                    height: 240,
-                    saveFn: saveText,
-                  ),
-                  const AudioPlayerWidget(),
-                ],
-              );
-            },
-            journalImage: (JournalImage image) {
-              QuillController _controller =
-                  makeController(serializedQuill: image.entryText?.quill);
-
-              void saveText() {
-                EntryText entryText = entryTextFromController(_controller);
-
-                context
-                    .read<PersistenceCubit>()
-                    .updateJournalEntity(widget.item, entryText);
-              }
-
-              return Column(
-                children: [
-                  EntryImageWidget(
-                    journalImage: image,
-                    height: 400,
-                  ),
-                  EditorWidget(
-                    controller: _controller,
-                    //height: 240,
-                    saveFn: saveText,
-                  ),
-                ],
-              );
-            },
-            journalEntry: (JournalEntry journalEntry) {
-              QuillController _controller =
-                  makeController(serializedQuill: journalEntry.entryText.quill);
-
-              void saveText() {
-                context.read<PersistenceCubit>().updateJournalEntity(
-                    widget.item, entryTextFromController(_controller));
-              }
-
-              return EditorWidget(
-                controller: _controller,
-                //height: 240,
-                saveFn: saveText,
-              );
-            },
-            measurement: (MeasurementEntry entry) {
-              QuillController _controller =
-                  makeController(serializedQuill: entry.entryText?.quill);
-
-              void saveText() {
-                context.read<PersistenceCubit>().updateJournalEntity(
-                    widget.item, entryTextFromController(_controller));
-              }
-
-              return EditorWidget(
-                controller: _controller,
-                //height: 240,
-                saveFn: saveText,
-              );
-            },
-            survey: (SurveyEntry surveyEntry) =>
-                SurveySummaryWidget(surveyEntry),
-            quantitative: (qe) => qe.data.map(
-              cumulativeQuantityData: (qd) => Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: InfoText(
-                  'End: ${df.format(qe.meta.dateTo)}'
-                  '\n${formatType(qd.dataType)}: '
-                  '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+            return Column(
+              children: [
+                EditorWidget(
+                  controller: _controller,
+                  height: 240,
+                  saveFn: saveText,
                 ),
-              ),
-              discreteQuantityData: (qd) => Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: InfoText(
-                  'End: ${df.format(qe.meta.dateTo)}'
-                  '\n${formatType(qd.dataType)}: '
-                  '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+                const AudioPlayerWidget(),
+              ],
+            );
+          },
+          journalImage: (JournalImage image) {
+            QuillController _controller =
+                makeController(serializedQuill: image.entryText?.quill);
+
+            void saveText() {
+              EntryText entryText = entryTextFromController(_controller);
+
+              context
+                  .read<PersistenceCubit>()
+                  .updateJournalEntity(widget.item, entryText);
+            }
+
+            return Column(
+              children: [
+                EntryImageWidget(
+                  journalImage: image,
+                  height: 400,
                 ),
+                EditorWidget(
+                  controller: _controller,
+                  readOnly: widget.readOnly,
+                  saveFn: saveText,
+                ),
+              ],
+            );
+          },
+          journalEntry: (JournalEntry journalEntry) {
+            QuillController _controller =
+                makeController(serializedQuill: journalEntry.entryText.quill);
+
+            void saveText() {
+              context.read<PersistenceCubit>().updateJournalEntity(
+                  widget.item, entryTextFromController(_controller));
+            }
+
+            return EditorWidget(
+              controller: _controller,
+              readOnly: widget.readOnly,
+              saveFn: saveText,
+            );
+          },
+          measurement: (MeasurementEntry entry) {
+            QuillController _controller =
+                makeController(serializedQuill: entry.entryText?.quill);
+
+            void saveText() {
+              context.read<PersistenceCubit>().updateJournalEntity(
+                  widget.item, entryTextFromController(_controller));
+            }
+
+            return EditorWidget(
+              controller: _controller,
+              readOnly: widget.readOnly,
+              saveFn: saveText,
+            );
+          },
+          survey: (SurveyEntry surveyEntry) => SurveySummaryWidget(surveyEntry),
+          quantitative: (qe) => qe.data.map(
+            cumulativeQuantityData: (qd) => Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: InfoText(
+                'End: ${df.format(qe.meta.dateTo)}'
+                '\n${formatType(qd.dataType)}: '
+                '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
               ),
             ),
-            orElse: () => Container(),
+            discreteQuantityData: (qd) => Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: InfoText(
+                'End: ${df.format(qe.meta.dateTo)}'
+                '\n${formatType(qd.dataType)}: '
+                '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+              ),
+            ),
           ),
-          widget.item.maybeMap(
-            journalAudio: (audio) => MapWidget(
-              geolocation: audio.geolocation,
-            ),
-            journalImage: (image) => MapWidget(
-              geolocation: image.geolocation,
-            ),
-            journalEntry: (entry) => MapWidget(
-              geolocation: entry.geolocation,
-            ),
-            measurement: (entry) => MapWidget(
-              geolocation: entry.geolocation,
-            ),
-            orElse: () => Container(),
+          orElse: () => Container(),
+        ),
+        widget.item.maybeMap(
+          journalAudio: (audio) => MapWidget(
+            geolocation: audio.geolocation,
           ),
-        ],
-      ),
+          journalImage: (image) => MapWidget(
+            geolocation: image.geolocation,
+          ),
+          journalEntry: (entry) => MapWidget(
+            geolocation: entry.geolocation,
+          ),
+          measurement: (entry) => MapWidget(
+            geolocation: entry.geolocation,
+          ),
+          orElse: () => Container(),
+        ),
+      ],
     );
   }
 }

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -207,8 +207,14 @@ class DetailRoute extends StatelessWidget {
         ),
         backgroundColor: AppColors.headerBgColor,
       ),
-      body: EntryDetailWidget(
-        item: item,
+      body: Container(
+        color: AppColors.bodyBgColor,
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: EntryDetailWidget(
+          item: item,
+        ),
       ),
     );
   }

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -212,8 +212,10 @@ class DetailRoute extends StatelessWidget {
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
         ),
-        child: EntryDetailWidget(
-          item: item,
+        child: SingleChildScrollView(
+          child: EntryDetailWidget(
+            item: item,
+          ),
         ),
       ),
     );

--- a/lotti/lib/widgets/pages/add/new_measurement_page.dart
+++ b/lotti/lib/widgets/pages/add/new_measurement_page.dart
@@ -75,7 +75,7 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                     }
                   },
                   child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 24.0),
+                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
                     child: Text(
                       'Save',
                       style: TextStyle(

--- a/lotti/lib/widgets/pages/settings/conflicts.dart
+++ b/lotti/lib/widgets/pages/settings/conflicts.dart
@@ -252,6 +252,13 @@ class DetailRoute extends StatelessWidget {
                   fontFamily: 'ShareTechMono',
                 ),
               ),
+              Text(
+                'Merged: ${withResolvedVectorClock.meta.vectorClock}',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontFamily: 'ShareTechMono',
+                ),
+              ),
               Padding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16.0,

--- a/lotti/lib/widgets/pages/settings/conflicts.dart
+++ b/lotti/lib/widgets/pages/settings/conflicts.dart
@@ -213,37 +213,45 @@ class DetailRoute extends StatelessWidget {
       ),
       backgroundColor: AppColors.bodyBgColor,
       body: SingleChildScrollView(
-        child: Column(
-          children: [
-            const Text(
-              'Local:',
-              style: TextStyle(color: Colors.white),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16.0,
-                vertical: 8,
+        child: Container(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom,
+          ),
+          child: Column(
+            children: [
+              const Text(
+                'Local:',
+                style: TextStyle(color: Colors.white),
               ),
-              child: ClipRRect(
-                borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-                child: EntryDetailWidget(item: local),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 8,
+                ),
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                  child: EntryDetailWidget(item: local),
+                ),
               ),
-            ),
-            const Text(
-              'From Sync:',
-              style: TextStyle(color: Colors.white),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16.0,
-                vertical: 8,
+              const Text(
+                'From Sync:',
+                style: TextStyle(color: Colors.white),
               ),
-              child: ClipRRect(
-                borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-                child: EntryDetailWidget(item: fromSync),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 8,
+                ),
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                  child: EntryDetailWidget(
+                    item: fromSync,
+                    readOnly: true,
+                  ),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lotti/lib/widgets/pages/settings/conflicts.dart
+++ b/lotti/lib/widgets/pages/settings/conflicts.dart
@@ -245,9 +245,12 @@ class DetailRoute extends StatelessWidget {
           ),
           child: Column(
             children: [
-              const Text(
-                'Local:',
-                style: TextStyle(color: Colors.white),
+              Text(
+                'Local: ${local.meta.vectorClock}',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontFamily: 'ShareTechMono',
+                ),
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(
@@ -259,9 +262,12 @@ class DetailRoute extends StatelessWidget {
                   child: EntryDetailWidget(item: withResolvedVectorClock),
                 ),
               ),
-              const Text(
-                'From Sync:',
-                style: TextStyle(color: Colors.white),
+              Text(
+                'From Sync: ${fromSync.meta.vectorClock}',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontFamily: 'ShareTechMono',
+                ),
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(

--- a/lotti/lib/widgets/pages/settings/conflicts.dart
+++ b/lotti/lib/widgets/pages/settings/conflicts.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lotti/blocs/sync/outbox_cubit.dart';
+import 'package:lotti/blocs/sync/outbox_state.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/conversions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_detail_widget.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+
+class ConflictsPage extends StatefulWidget {
+  const ConflictsPage({Key? key}) : super(key: key);
+
+  @override
+  State<ConflictsPage> createState() => _ConflictsPageState();
+}
+
+class _ConflictsPageState extends State<ConflictsPage> {
+  final JournalDb _db = getIt<JournalDb>();
+
+  late Stream<List<Conflict>> stream =
+      _db.watchConflicts(ConflictStatus.unprocessed);
+
+  String _selectedValue = 'unresolved';
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<OutboxCubit, OutboxState>(
+      builder: (context, OutboxState state) {
+        return StreamBuilder<List<Conflict>>(
+          stream: stream,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<List<Conflict>> snapshot,
+          ) {
+            List<Conflict> items = snapshot.data ?? [];
+
+            return Scaffold(
+              appBar: AppBar(
+                backgroundColor: AppColors.headerBgColor,
+                foregroundColor: AppColors.appBarFgColor,
+                title: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    CupertinoSegmentedControl(
+                      selectedColor: AppColors.entryBgColor,
+                      unselectedColor: AppColors.headerBgColor,
+                      borderColor: AppColors.entryBgColor,
+                      groupValue: _selectedValue,
+                      onValueChanged: (String value) {
+                        setState(() {
+                          _selectedValue = value;
+                          if (_selectedValue == 'unresolved') {
+                            stream =
+                                _db.watchConflicts(ConflictStatus.unprocessed);
+                          }
+                          if (_selectedValue == 'resolved') {
+                            stream =
+                                _db.watchConflicts(ConflictStatus.resolved);
+                          }
+                        });
+                      },
+                      children: const {
+                        'unresolved': SizedBox(
+                          width: 64,
+                          height: 32,
+                          child: Center(
+                            child: Text(
+                              'unresolved',
+                              style: TextStyle(
+                                fontFamily: 'Oswald',
+                                fontSize: 14,
+                              ),
+                            ),
+                          ),
+                        ),
+                        'resolved': SizedBox(
+                          child: Center(
+                            child: Text(
+                              'resolved',
+                              style: TextStyle(
+                                fontFamily: 'Oswald',
+                                fontSize: 14,
+                              ),
+                            ),
+                          ),
+                        ),
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              backgroundColor: AppColors.bodyBgColor,
+              body: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(8.0),
+                children: List.generate(
+                  items.length,
+                  (int index) {
+                    return ConflictCard(
+                      conflict: items.elementAt(index),
+                      db: _db,
+                      index: index,
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class ConflictCard extends StatelessWidget {
+  final Conflict conflict;
+  final JournalDb db;
+  final int index;
+
+  const ConflictCard({
+    Key? key,
+    required this.conflict,
+    required this.db,
+    required this.index,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: Card(
+        elevation: 8.0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8.0),
+        ),
+        child: ListTile(
+          contentPadding: const EdgeInsets.only(left: 24, right: 24),
+          title: Text(
+            '${df.format(conflict.createdAt)} - ${conflict.status}',
+            style: TextStyle(
+              color: AppColors.entryTextColor,
+              fontFamily: 'Oswald',
+              fontSize: 16.0,
+            ),
+          ),
+          subtitle: Text(
+            '$conflict',
+            style: TextStyle(
+              color: AppColors.entryTextColor,
+              fontFamily: 'Oswald',
+              fontWeight: FontWeight.w200,
+              fontSize: 16.0,
+            ),
+          ),
+          enabled: true,
+          onTap: () async {
+            JournalEntity? entity = await db.journalEntityById(conflict.id);
+            if (entity == null) return;
+
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (BuildContext context) {
+                  return DetailRoute(
+                    local: entity,
+                    conflict: conflict,
+                    index: index,
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class DetailRoute extends StatelessWidget {
+  const DetailRoute({
+    Key? key,
+    required this.local,
+    required this.index,
+    required this.conflict,
+  }) : super(key: key);
+
+  final int index;
+  final JournalEntity local;
+  final Conflict conflict;
+
+  @override
+  Widget build(BuildContext context) {
+    final JournalEntity fromSync = fromSerialized(conflict.serialized);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          df.format(local.meta.dateFrom),
+          style: TextStyle(
+            color: AppColors.entryBgColor,
+            fontFamily: 'Oswald',
+          ),
+        ),
+        backgroundColor: AppColors.headerBgColor,
+      ),
+      backgroundColor: AppColors.bodyBgColor,
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            const Text(
+              'Local:',
+              style: TextStyle(color: Colors.white),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16.0,
+                vertical: 8,
+              ),
+              child: ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                child: EntryDetailWidget(item: local),
+              ),
+            ),
+            const Text(
+              'From Sync:',
+              style: TextStyle(color: Colors.white),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16.0,
+                vertical: 8,
+              ),
+              child: ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                child: EntryDetailWidget(item: fromSync),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lotti/lib/widgets/pages/settings/conflicts.dart
+++ b/lotti/lib/widgets/pages/settings/conflicts.dart
@@ -1,3 +1,4 @@
+import 'package:enum_to_string/enum_to_string.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -121,6 +122,10 @@ class _ConflictsPageState extends State<ConflictsPage> {
   }
 }
 
+String statusString(Conflict conflict) {
+  return EnumToString.convertToString(ConflictStatus.values[conflict.status]);
+}
+
 class ConflictCard extends StatelessWidget {
   final JournalDb _db = getIt<JournalDb>();
 
@@ -145,7 +150,7 @@ class ConflictCard extends StatelessWidget {
         child: ListTile(
           contentPadding: const EdgeInsets.only(left: 24, right: 24),
           title: Text(
-            '${df.format(conflict.createdAt)} - ${conflict.status}',
+            '${df.format(conflict.createdAt)} - ${statusString(conflict)}',
             style: TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
@@ -153,7 +158,7 @@ class ConflictCard extends StatelessWidget {
             ),
           ),
           subtitle: Text(
-            '$conflict',
+            '${fromSerialized(conflict.serialized).meta.vectorClock}',
             style: TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
@@ -185,9 +190,7 @@ class ConflictCard extends StatelessWidget {
 }
 
 class DetailRoute extends StatelessWidget {
-  final JournalDb _db = getIt<JournalDb>();
-
-  DetailRoute({
+  const DetailRoute({
     Key? key,
     required this.local,
     required this.index,
@@ -216,26 +219,6 @@ class DetailRoute extends StatelessWidget {
           ),
         ),
         backgroundColor: AppColors.headerBgColor,
-        actions: <Widget>[
-          TextButton(
-            onPressed: () async {
-              _db.resolveConflict(conflict);
-              Navigator.pop(context);
-            },
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: 24.0),
-              child: Text(
-                'Resolve',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontFamily: 'Oswald',
-                  fontWeight: FontWeight.bold,
-                  color: AppColors.appBarFgColor,
-                ),
-              ),
-            ),
-          ),
-        ],
       ),
       backgroundColor: AppColors.bodyBgColor,
       body: SingleChildScrollView(

--- a/lotti/lib/widgets/pages/settings/outbox_monitor.dart
+++ b/lotti/lib/widgets/pages/settings/outbox_monitor.dart
@@ -38,6 +38,7 @@ class _OutboxMonitorPageState extends State<OutboxMonitorPage> {
             AsyncSnapshot<List<OutboxItem>> snapshot,
           ) {
             List<OutboxItem> items = snapshot.data ?? [];
+            bool onlineStatus = state is! OutboxDisabled;
 
             return Scaffold(
               appBar: AppBar(
@@ -105,15 +106,12 @@ class _OutboxMonitorPageState extends State<OutboxMonitorPage> {
                         ),
                       },
                     ),
-                    IconButton(
-                        icon: const Icon(Icons.refresh),
-                        iconSize: 32,
-                        tooltip: 'Restart',
-                        color: AppColors.entryBgColor,
-                        onPressed: () {
-                          context.read<OutboxCubit>().stopPolling();
-                          context.read<OutboxCubit>().startPolling();
-                        })
+                    CupertinoSwitch(
+                      value: onlineStatus,
+                      onChanged: (_) {
+                        context.read<OutboxCubit>().toggleStatus();
+                      },
+                    ),
                   ],
                 ),
               ),

--- a/lotti/lib/widgets/pages/settings/settings_page.dart
+++ b/lotti/lib/widgets/pages/settings/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/blocs/journal/persistence_state.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/misc/app_bar_version.dart';
+import 'package:lotti/widgets/pages/settings/conflicts.dart';
 import 'package:lotti/widgets/pages/settings/measurables.dart';
 import 'package:lotti/widgets/pages/settings/outbox_monitor.dart';
 import 'package:lotti/widgets/pages/settings/sync_settings.dart';
@@ -81,6 +82,19 @@ class _SettingsPageState extends State<SettingsPage> {
                               MaterialPageRoute(
                                 builder: (BuildContext context) {
                                   return const OutboxMonitorPage();
+                                },
+                              ),
+                            );
+                          },
+                        ),
+                        SettingsCard(
+                          iconData: MdiIcons.emoticonConfused,
+                          title: 'Conflicts',
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (BuildContext context) {
+                                  return const ConflictsPage();
                                 },
                               ),
                             );

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+188
+version: 0.3.10+189
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+185
+version: 0.3.10+186
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.9+182
+version: 0.3.10+184
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+184
+version: 0.3.10+185
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+186
+version: 0.3.10+187
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+187
+version: 0.3.10+188
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a basic conflict resolution mechanism that shows the local version, with editable text, and the conflicting version from sync in read-only mode so that the user can manually merge the text. Then, when clicking the save button, a new version is created that takes the counter of the originating host into account and creates a new version that's strictly higher than both the local entry and the conflicting one. The conflict is then resolved automatically when such an entry is either persisted locally, or, on a remote host, received via sync.