### PR TITLE
Entry improvements

### DIFF
--- a/lotti/lib/classes/journal_entities.dart
+++ b/lotti/lib/classes/journal_entities.dart
@@ -111,6 +111,7 @@ class JournalEntity with _$JournalEntity {
   const factory JournalEntity.quantitative({
     required Metadata meta,
     required QuantitativeData data,
+    Geolocation? geolocation,
   }) = QuantitativeEntry;
 
   const factory JournalEntity.measurement({

--- a/lotti/lib/classes/journal_entities.dart
+++ b/lotti/lib/classes/journal_entities.dart
@@ -23,7 +23,7 @@ class Metadata with _$Metadata {
     int? utcOffset,
     String? timezone,
     VectorClock? vectorClock,
-    bool? deleted,
+    DateTime? deletedAt,
   }) = _Metadata;
 
   factory Metadata.fromJson(Map<String, dynamic> json) =>

--- a/lotti/lib/classes/journal_entities.dart
+++ b/lotti/lib/classes/journal_entities.dart
@@ -23,6 +23,7 @@ class Metadata with _$Metadata {
     int? utcOffset,
     String? timezone,
     VectorClock? vectorClock,
+    bool? deleted,
   }) = _Metadata;
 
   factory Metadata.fromJson(Map<String, dynamic> json) =>

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -6,31 +6,32 @@ import 'package:lotti/classes/measurables.dart';
 
 import 'database.dart';
 
-JournalDbEntity toDbEntity(JournalEntity journalEntity) {
-  final DateTime createdAt = journalEntity.meta.createdAt;
-  final subtype = journalEntity.maybeMap(
+JournalDbEntity toDbEntity(JournalEntity entity) {
+  final DateTime createdAt = entity.meta.createdAt;
+  final subtype = entity.maybeMap(
     quantitative: (qd) => qd.data.dataType,
     survey: (SurveyEntry surveyEntry) => surveyEntry.data.taskResult.identifier,
     orElse: () => '',
   );
 
   Geolocation? geolocation;
-  journalEntity.mapOrNull(
+  entity.mapOrNull(
     journalAudio: (item) => geolocation = item.geolocation,
     journalImage: (item) => geolocation = item.geolocation,
     journalEntry: (item) => geolocation = item.geolocation,
   );
 
-  String id = journalEntity.meta.id;
+  String id = entity.meta.id;
   JournalDbEntity dbEntity = JournalDbEntity(
     id: id,
     createdAt: createdAt,
     updatedAt: createdAt,
-    dateFrom: journalEntity.meta.dateFrom,
-    dateTo: journalEntity.meta.dateTo,
-    type: journalEntity.runtimeType.toString(),
+    dateFrom: entity.meta.dateFrom,
+    deleted: entity.meta.deleted ?? false,
+    dateTo: entity.meta.dateTo,
+    type: entity.runtimeType.toString(),
     subtype: subtype,
-    serialized: json.encode(journalEntity),
+    serialized: json.encode(entity),
     schemaVersion: 0,
     longitude: geolocation?.longitude,
     latitude: geolocation?.latitude,

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -27,7 +27,7 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
     createdAt: createdAt,
     updatedAt: createdAt,
     dateFrom: entity.meta.dateFrom,
-    deleted: entity.meta.deleted ?? false,
+    deleted: entity.meta.deletedAt != null,
     dateTo: entity.meta.dateTo,
     type: entity.runtimeType.toString(),
     subtype: subtype,

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -5,6 +5,7 @@ CREATE TABLE journal (
   updated_at DATETIME NOT NULL,
   date_from DATETIME NOT NULL,
   date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
   type TEXT NOT NULL,
   subtype TEXT,
   serialized TEXT NOT NULL,
@@ -28,6 +29,9 @@ ON journal (date_from);
 
 CREATE INDEX idx_journal_date_to
 ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted
+ON journal (deleted);
 
 CREATE INDEX idx_journal_type
 ON journal (type);
@@ -67,12 +71,13 @@ CREATE TABLE measurable_types (
 /* Queries ----------------------------------------------------- */
 filteredJournal:
 SELECT * FROM journal
-  WHERE type IN :types
+  WHERE type IN :types AND deleted = false
   ORDER BY date_from DESC
   LIMIT :limit;
 
 orderedJournal:
 SELECT * FROM journal
+  WHERE deleted = false
   ORDER BY date_from DESC
   LIMIT :limit;
 

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -161,7 +161,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
               child: Text(df.format(widget.item.meta.dateFrom)),
             ),
             Visibility(
-              visible: loc != null,
+              visible: loc != null && loc.longitude != 0,
               child: TextButton(
                 onPressed: () => setState(() {
                   mapVisible = !mapVisible;

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -173,7 +173,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
             IconButton(
               icon: const Icon(MdiIcons.trashCanOutline),
               iconSize: 24,
-              tooltip: 'Stop',
+              tooltip: 'Delete',
               color: AppColors.appBarFgColor,
               onPressed: () {
                 context

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -175,7 +175,12 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
               iconSize: 24,
               tooltip: 'Stop',
               color: AppColors.appBarFgColor,
-              onPressed: () {},
+              onPressed: () {
+                context
+                    .read<PersistenceCubit>()
+                    .deleteJournalEntity(widget.item);
+                Navigator.pop(context);
+              },
             ),
           ],
         ),

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -6,6 +6,7 @@ import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/theme.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
@@ -13,6 +14,7 @@ import 'package:lotti/widgets/journal/editor_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:lotti/widgets/misc/map_widget.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/src/provider.dart';
 
@@ -151,15 +153,31 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           ),
           orElse: () => Container(),
         ),
-        Visibility(
-          visible: loc != null,
-          child: TextButton(
-            onPressed: () => setState(() {
-              mapVisible = !mapVisible;
-            }),
-            child: Text('${latLonFormat.format(loc?.latitude)}, '
-                '${latLonFormat.format(loc?.longitude)}'),
-          ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            TextButton(
+              onPressed: () {},
+              child: Text(df.format(widget.item.meta.dateFrom)),
+            ),
+            Visibility(
+              visible: loc != null,
+              child: TextButton(
+                onPressed: () => setState(() {
+                  mapVisible = !mapVisible;
+                }),
+                child: Text('${latLonFormat.format(loc?.latitude)}, '
+                    '${latLonFormat.format(loc?.longitude)}'),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(MdiIcons.trashCanOutline),
+              iconSize: 24,
+              tooltip: 'Stop',
+              color: AppColors.appBarFgColor,
+              onPressed: () {},
+            ),
+          ],
         ),
         Visibility(
           visible: mapVisible,

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
@@ -30,6 +31,7 @@ class EntryDetailWidget extends StatefulWidget {
 
 class _EntryDetailWidgetState extends State<EntryDetailWidget> {
   Directory? docDir;
+  bool mapVisible = false;
 
   @override
   void initState() {
@@ -44,6 +46,8 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
   @override
   Widget build(BuildContext context) {
+    Geolocation? loc = widget.item.geolocation;
+
     return Column(
       children: <Widget>[
         widget.item.maybeMap(
@@ -147,20 +151,21 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           ),
           orElse: () => Container(),
         ),
-        widget.item.maybeMap(
-          journalAudio: (audio) => MapWidget(
-            geolocation: audio.geolocation,
+        Visibility(
+          visible: loc != null,
+          child: TextButton(
+            onPressed: () => setState(() {
+              mapVisible = !mapVisible;
+            }),
+            child: Text('${latLonFormat.format(loc?.latitude)}, '
+                '${latLonFormat.format(loc?.longitude)}'),
           ),
-          journalImage: (image) => MapWidget(
-            geolocation: image.geolocation,
+        ),
+        Visibility(
+          visible: mapVisible,
+          child: MapWidget(
+            geolocation: widget.item.geolocation,
           ),
-          journalEntry: (entry) => MapWidget(
-            geolocation: entry.geolocation,
-          ),
-          measurement: (entry) => MapWidget(
-            geolocation: entry.geolocation,
-          ),
-          orElse: () => Container(),
         ),
       ],
     );

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -166,8 +166,8 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                 onPressed: () => setState(() {
                   mapVisible = !mapVisible;
                 }),
-                child: Text('${latLonFormat.format(loc?.latitude)}, '
-                    '${latLonFormat.format(loc?.longitude)}'),
+                child: Text('📍 ${formatLatLon(loc?.latitude)}, '
+                    '${formatLatLon(loc?.longitude)}'),
               ),
             ),
             IconButton(

--- a/lotti/lib/widgets/journal/entry_tools.dart
+++ b/lotti/lib/widgets/journal/entry_tools.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 
 NumberFormat nf = NumberFormat('###.##');
+NumberFormat latLonFormat = NumberFormat('###.####');
 DateFormat df = DateFormat('yyyy-MM-dd HH:mm:ss');
 
 String formatType(String s) => s.replaceAll('HealthDataType.', '');

--- a/lotti/lib/widgets/journal/entry_tools.dart
+++ b/lotti/lib/widgets/journal/entry_tools.dart
@@ -4,7 +4,17 @@ import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 
 NumberFormat nf = NumberFormat('###.##');
+
 NumberFormat latLonFormat = NumberFormat('###.####');
+
+String formatLatLon(double? number) {
+  if (number != null) {
+    return latLonFormat.format(number);
+  } else {
+    return '';
+  }
+}
+
 DateFormat df = DateFormat('yyyy-MM-dd HH:mm:ss');
 
 String formatType(String s) => s.replaceAll('HealthDataType.', '');

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -197,6 +197,7 @@ class DetailRoute extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
       appBar: AppBar(
         title: Text(
           df.format(item.meta.dateFrom),

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.11+194
+version: 0.3.11+195
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.11+192
+version: 0.3.11+193
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.11+193
+version: 0.3.11+194
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.10+189
+version: 0.3.11+190
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.11+191
+version: 0.3.11+192
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -84,6 +84,10 @@ dev_dependencies:
   glados: ^1.0.2
   json_serializable: ^6.0.0
   sentry_dart_plugin: ^1.0.0-beta.1
+
+analyzer:
+  plugins:
+    - drift
 
 flutter:
   uses-material-design: true

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.11+190
+version: 0.3.11+191
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds an entry footer with a delete button, which currently marks an entry as deleted without further confirmation by the user. There should be a confirmation prompt here. Entries aren't deleted completely - for that, either an `Empty Bin` or eviction after a certain amount of time need to be implemented, probably both.

Also, a toggle text button with the lat/lon coordinates for the display of the map is added and the map hidden by default.