### PR TITLE
Add delete button for measurable types

### DIFF
--- a/lotti/lib/classes/measurables.dart
+++ b/lotti/lib/classes/measurables.dart
@@ -16,6 +16,7 @@ class EntityDefinition with _$EntityDefinition {
     required String unitName,
     required int version,
     required VectorClock? vectorClock,
+    DateTime? deletedAt,
   }) = MeasurableDataType;
 
   factory EntityDefinition.fromJson(Map<String, dynamic> json) =>

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -49,8 +49,17 @@ JournalEntity fromDbEntity(JournalDbEntity dbEntity) {
   return fromSerialized(dbEntity.serialized);
 }
 
+List<JournalEntity> entityStreamMapper(List<JournalDbEntity> dbEntities) {
+  return dbEntities.map((e) => fromDbEntity(e)).toList();
+}
+
 MeasurableDataType measurableDataType(MeasurableDbEntity dbEntity) {
   return MeasurableDataType.fromJson(json.decode(dbEntity.serialized));
+}
+
+List<MeasurableDataType> measurableDataTypeStreamMapper(
+    List<MeasurableDbEntity> dbEntities) {
+  return dbEntities.map((e) => measurableDataType(e)).toList();
 }
 
 MeasurableDbEntity measurableDbEntity(EntityDefinition dataType) {
@@ -62,5 +71,6 @@ MeasurableDbEntity measurableDbEntity(EntityDefinition dataType) {
     serialized: jsonEncode(dataType),
     version: dataType.version,
     status: 0,
+    deleted: dataType.deletedAt != null,
   );
 }

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -126,10 +126,6 @@ class JournalDb extends _$JournalDb {
     }
   }
 
-  List<JournalEntity> entityStreamMapper(List<JournalDbEntity> dbEntities) {
-    return dbEntities.map((e) => fromDbEntity(e)).toList();
-  }
-
   Stream<List<JournalEntity>> watchJournalEntities({
     required List<String> types,
     int limit = 1000,
@@ -138,10 +134,7 @@ class JournalDb extends _$JournalDb {
   }
 
   Stream<List<MeasurableDataType>> watchMeasurableDataTypes() {
-    return (select(measurableTypes)
-          ..orderBy([(t) => OrderingTerm(expression: t.uniqueName)]))
-        .map(measurableDataType)
-        .watch();
+    return activeMeasurableTypes().watch().map(measurableDataTypeStreamMapper);
   }
 
   Stream<List<Conflict>> watchConflicts(

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -62,6 +62,7 @@ CREATE TABLE measurable_types (
   unique_name TEXT NOT NULL UNIQUE,
   created_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
   serialized TEXT NOT NULL,
   version INTEGER NOT NULL DEFAULT 0,
   status INTEGER NOT NULL,
@@ -86,3 +87,8 @@ SELECT * FROM conflicts
   WHERE status = :status
   ORDER BY created_at DESC
   LIMIT :limit;
+
+activeMeasurableTypes:
+SELECT * FROM measurable_types
+  WHERE deleted = false
+  ORDER BY unique_name ASC;

--- a/lotti/lib/widgets/pages/settings/measurables.dart
+++ b/lotti/lib/widgets/pages/settings/measurables.dart
@@ -258,33 +258,61 @@ class _DetailRouteState extends State<DetailRoute> {
                 child: Container(
                   color: AppColors.headerBgColor,
                   padding: const EdgeInsets.all(24.0),
-                  child: FormBuilder(
-                    key: _formKey,
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    child: Column(
-                      children: <Widget>[
-                        FormTextField(
-                          initialValue: item.name,
-                          labelText: 'Name',
-                          name: 'name',
+                  child: Column(
+                    children: [
+                      FormBuilder(
+                        key: _formKey,
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                        child: Column(
+                          children: <Widget>[
+                            FormTextField(
+                              initialValue: item.name,
+                              labelText: 'Name',
+                              name: 'name',
+                            ),
+                            FormTextField(
+                              initialValue: item.displayName,
+                              labelText: 'Display name',
+                              name: 'displayName',
+                            ),
+                            FormTextField(
+                              initialValue: item.description,
+                              labelText: 'Description',
+                              name: 'description',
+                            ),
+                            FormTextField(
+                              initialValue: item.unitName,
+                              labelText: 'Unit abbreviation',
+                              name: 'unitName',
+                            ),
+                          ],
                         ),
-                        FormTextField(
-                          initialValue: item.displayName,
-                          labelText: 'Display name',
-                          name: 'displayName',
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            IconButton(
+                              icon: const Icon(MdiIcons.trashCanOutline),
+                              iconSize: 24,
+                              tooltip: 'Delete',
+                              color: AppColors.appBarFgColor,
+                              onPressed: () {
+                                context
+                                    .read<PersistenceCubit>()
+                                    .upsertEntityDefinition(
+                                      item.copyWith(
+                                        deletedAt: DateTime.now(),
+                                      ),
+                                    );
+                                Navigator.pop(context);
+                              },
+                            ),
+                          ],
                         ),
-                        FormTextField(
-                          initialValue: item.description,
-                          labelText: 'Description',
-                          name: 'description',
-                        ),
-                        FormTextField(
-                          initialValue: item.unitName,
-                          labelText: 'Unit abbreviation',
-                          name: 'unitName',
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.12+196
+version: 0.3.13+197
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a delete button for measurable types. Same as for journal entries, the database entities are marked as deleted, but not removed. Cleanup, e.g. empty bin, can be implemented later.