### PR TITLE
Set entry start and end dates

### DIFF
--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -111,6 +111,15 @@ class JournalDb extends _$JournalDb {
     }
   }
 
+  Stream<JournalEntity?> watchEntityById(String id) {
+    Stream<JournalEntity?> res = (select(journal)
+          ..where((t) => t.id.equals(id)))
+        .watch()
+        .map(entityStreamMapper)
+        .map((event) => event.first);
+    return res;
+  }
+
   Future<Conflict?> conflictById(String id) async {
     List<Conflict> res =
         await (select(conflicts)..where((t) => t.id.equals(id))).get();

--- a/lotti/lib/main.dart
+++ b/lotti/lib/main.dart
@@ -113,7 +113,6 @@ class LottiApp extends StatelessWidget {
         home: const HomePage(),
         supportedLocales: const [
           Locale('en'),
-          Locale('de'),
         ],
         localizationsDelegates: const [FormBuilderLocalizations.delegate],
       ),

--- a/lotti/lib/theme.dart
+++ b/lotti/lib/theme.dart
@@ -4,7 +4,7 @@ import 'package:tinycolor2/tinycolor2.dart';
 class AppColors {
   static Color bodyBgColor = const Color.fromRGBO(47, 47, 59, 1);
   static Color entryBgColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color entryTextColor = const Color.fromRGBO(180, 190, 200, 1);
+  static Color entryTextColor = const Color.fromRGBO(158, 158, 158, 1);
   static Color editorBgColor = Colors.white;
 
   static Color headerBgColor = const Color.fromRGBO(68, 68, 85, 1);
@@ -19,6 +19,7 @@ class AppColors {
   static Color audioMeterBar = Colors.blue;
   static Color audioMeterTooHotBar = Colors.orange;
   static Color audioMeterPeakedBar = Colors.red;
+  static Color error = Colors.red;
   static Color audioMeterBarBackground =
       TinyColor(headerBgColor).lighten(40).color;
   static Color inactiveAudioControl = const Color.fromRGBO(155, 155, 177, 1);
@@ -28,3 +29,32 @@ class AppColors {
 class AppNumbers {
   static const double borderRadius = 3.0;
 }
+
+TextStyle inputStyle = TextStyle(
+  color: AppColors.entryTextColor,
+  fontWeight: FontWeight.bold,
+  fontFamily: 'Lato',
+  fontSize: 18.0,
+);
+
+TextStyle textStyle = TextStyle(
+  color: AppColors.entryTextColor,
+  fontWeight: FontWeight.bold,
+  fontFamily: 'Lato',
+  fontSize: 14.0,
+);
+
+TextStyle textStyleLarger = textStyle.copyWith(
+  fontSize: 18,
+  fontWeight: FontWeight.normal,
+);
+
+TextStyle labelStyleLarger = textStyleLarger.copyWith(
+  fontSize: 18,
+  fontWeight: FontWeight.w300,
+);
+
+TextStyle labelStyle = TextStyle(
+  color: AppColors.entryTextColor,
+  fontSize: 16.0,
+);

--- a/lotti/lib/widgets/journal/entry_datetime_modal.dart
+++ b/lotti/lib/widgets/journal/entry_datetime_modal.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
+import 'package:lotti/blocs/journal/persistence_cubit.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:provider/src/provider.dart';
+
+class EntryDateTimeModal extends StatefulWidget {
+  final JournalEntity item;
+  final bool readOnly;
+  const EntryDateTimeModal({
+    Key? key,
+    required this.item,
+    this.readOnly = false,
+  }) : super(key: key);
+
+  @override
+  _EntryDateTimeModalState createState() => _EntryDateTimeModalState();
+}
+
+class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
+  late DateTime dateFrom;
+  late DateTime dateTo;
+
+  @override
+  void initState() {
+    super.initState();
+    dateFrom = widget.item.meta.dateFrom;
+    dateTo = widget.item.meta.dateTo;
+  }
+
+  void showDatePicker({
+    required Function(DateTime) onConfirm,
+    required DateTime currentTime,
+  }) {
+    DatePicker.showDateTimePicker(
+      context,
+      showTitleActions: true,
+      theme: DatePickerTheme(
+        headerColor: AppColors.headerBgColor,
+        backgroundColor: AppColors.bodyBgColor,
+        itemStyle: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 18,
+        ),
+        doneStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+        ),
+      ),
+      onConfirm: onConfirm,
+      currentTime: currentTime,
+      locale: LocaleType.en,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    bool valid = dateTo.isAfter(dateFrom) || dateTo == dateFrom;
+    bool changed = dateFrom != widget.item.meta.dateFrom ||
+        dateTo != widget.item.meta.dateTo;
+
+    return Container(
+      height: 150,
+      color: AppColors.bodyBgColor,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: <Widget>[
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  child: Text(
+                    'Date from: ',
+                    textAlign: TextAlign.end,
+                    style: labelStyleLarger,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    showDatePicker(
+                      onConfirm: (DateTime date) {
+                        setState(() {
+                          dateFrom = date;
+                        });
+                      },
+                      currentTime: dateFrom,
+                    );
+                  },
+                  child: Text(
+                    df.format(dateFrom),
+                    style: textStyleLarger,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(
+              height: 8,
+            ),
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  child: Text(
+                    'Date to:',
+                    textAlign: TextAlign.end,
+                    style: labelStyleLarger,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    showDatePicker(
+                      onConfirm: (DateTime date) {
+                        setState(() {
+                          dateTo = date;
+                        });
+                      },
+                      currentTime: dateTo,
+                    );
+                  },
+                  child: Text(
+                    df.format(dateTo),
+                    style: textStyleLarger,
+                  ),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Visibility(
+                    visible: valid && changed,
+                    child: TextButton(
+                      onPressed: () async {
+                        await context
+                            .read<PersistenceCubit>()
+                            .updateJournalEntityDate(
+                              widget.item,
+                              dateFrom: dateFrom,
+                              dateTo: dateTo,
+                            );
+                        Navigator.pop(context);
+                      },
+                      child: Text(
+                        'SAVE',
+                        style: textStyleLarger,
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible: !valid,
+                    child: Text(
+                      'Invalid Date Range',
+                      style: textStyleLarger.copyWith(color: AppColors.error),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lotti/lib/widgets/journal/entry_detail_route.dart
+++ b/lotti/lib/widgets/journal/entry_detail_route.dart
@@ -1,8 +1,56 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/entry_detail_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
+
+class EntryAppBarTitle extends StatefulWidget {
+  final JournalEntity item;
+  const EntryAppBarTitle({
+    Key? key,
+    required this.item,
+  }) : super(key: key);
+
+  @override
+  _EntryAppBarTitleState createState() => _EntryAppBarTitleState();
+}
+
+class _EntryAppBarTitleState extends State<EntryAppBarTitle> {
+  final JournalDb _db = getIt<JournalDb>();
+  late Stream<JournalEntity?> stream;
+
+  @override
+  void initState() {
+    super.initState();
+    stream = _db.watchEntityById(widget.item.meta.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<JournalEntity?> snapshot,
+        ) {
+          JournalEntity? journalEntity = snapshot.data;
+
+          if (journalEntity == null) {
+            return Container();
+          }
+
+          return Text(
+            df.format(journalEntity.meta.dateFrom),
+            style: TextStyle(
+              color: AppColors.entryBgColor,
+              fontFamily: 'Oswald',
+            ),
+          );
+        });
+  }
+}
 
 class EntryDetailRoute extends StatelessWidget {
   const EntryDetailRoute({
@@ -19,12 +67,8 @@ class EntryDetailRoute extends StatelessWidget {
     return Scaffold(
       backgroundColor: AppColors.bodyBgColor,
       appBar: AppBar(
-        title: Text(
-          df.format(item.meta.dateFrom),
-          style: TextStyle(
-            color: AppColors.entryBgColor,
-            fontFamily: 'Oswald',
-          ),
+        title: EntryAppBarTitle(
+          item: item,
         ),
         backgroundColor: AppColors.headerBgColor,
       ),

--- a/lotti/lib/widgets/journal/entry_detail_route.dart
+++ b/lotti/lib/widgets/journal/entry_detail_route.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_detail_widget.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+
+class EntryDetailRoute extends StatelessWidget {
+  const EntryDetailRoute({
+    Key? key,
+    required this.item,
+    required this.index,
+  }) : super(key: key);
+
+  final int index;
+  final JournalEntity item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: AppBar(
+        title: Text(
+          df.format(item.meta.dateFrom),
+          style: TextStyle(
+            color: AppColors.entryBgColor,
+            fontFamily: 'Oswald',
+          ),
+        ),
+        backgroundColor: AppColors.headerBgColor,
+      ),
+      body: Container(
+        color: AppColors.bodyBgColor,
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: SingleChildScrollView(
+          child: EntryDetailWidget(
+            item: item,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -63,7 +63,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
               context
                   .read<PersistenceCubit>()
-                  .updateJournalEntity(widget.item, entryText);
+                  .updateJournalEntityText(widget.item, entryText);
             }
 
             return Column(
@@ -86,7 +86,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
               context
                   .read<PersistenceCubit>()
-                  .updateJournalEntity(widget.item, entryText);
+                  .updateJournalEntityText(widget.item, entryText);
             }
 
             return Column(
@@ -108,7 +108,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                 makeController(serializedQuill: journalEntry.entryText.quill);
 
             void saveText() {
-              context.read<PersistenceCubit>().updateJournalEntity(
+              context.read<PersistenceCubit>().updateJournalEntityText(
                   widget.item, entryTextFromController(_controller));
             }
 
@@ -123,7 +123,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                 makeController(serializedQuill: entry.entryText?.quill);
 
             void saveText() {
-              context.read<PersistenceCubit>().updateJournalEntity(
+              context.read<PersistenceCubit>().updateJournalEntityText(
                   widget.item, entryTextFromController(_controller));
             }
 
@@ -159,33 +159,26 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           children: [
             TextButton(
               onPressed: () {
-                DatePicker.showDateTimePicker(
-                  context,
-                  showTitleActions: true,
-                  theme: DatePickerTheme(
-                    headerColor: Colors.orange,
-                    backgroundColor: AppColors.entryBgColor,
-                    itemStyle: TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 18),
-                    doneStyle: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(
+                      top: Radius.circular(16),
                     ),
                   ),
-                  onChanged: (date) {
-                    print('change $date in time zone ' +
-                        date.timeZoneOffset.inHours.toString());
+                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                  builder: (BuildContext context) {
+                    return EntryDateTimeModal(
+                      item: widget.item,
+                    );
                   },
-                  onConfirm: (date) {
-                    print('confirm $date');
-                  },
-                  currentTime: DateTime.now(),
-                  locale: LocaleType.en,
                 );
               },
-              child: Text(df.format(widget.item.meta.dateFrom)),
+              child: Text(
+                df.format(widget.item.meta.dateFrom),
+                style: textStyle,
+              ),
             ),
             Visibility(
               visible: loc != null && loc.longitude != 0,
@@ -193,8 +186,11 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                 onPressed: () => setState(() {
                   mapVisible = !mapVisible;
                 }),
-                child: Text('📍 ${formatLatLon(loc?.latitude)}, '
-                    '${formatLatLon(loc?.longitude)}'),
+                child: Text(
+                  '📍 ${formatLatLon(loc?.latitude)}, '
+                  '${formatLatLon(loc?.longitude)}',
+                  style: textStyle,
+                ),
               ),
             ),
             IconButton(
@@ -272,5 +268,168 @@ class _EntryImageWidgetState extends State<EntryImageWidget> {
     } else {
       return Container();
     }
+  }
+}
+
+class EntryDateTimeModal extends StatefulWidget {
+  final JournalEntity item;
+  final bool readOnly;
+  const EntryDateTimeModal({
+    Key? key,
+    required this.item,
+    this.readOnly = false,
+  }) : super(key: key);
+
+  @override
+  _EntryDateTimeModalState createState() => _EntryDateTimeModalState();
+}
+
+class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
+  late DateTime dateFrom;
+  late DateTime dateTo;
+
+  @override
+  void initState() {
+    super.initState();
+    dateFrom = widget.item.meta.dateFrom;
+    dateTo = widget.item.meta.dateTo;
+  }
+
+  void showDatePicker({
+    required Function(DateTime) onConfirm,
+    required DateTime currentTime,
+  }) {
+    DatePicker.showDateTimePicker(
+      context,
+      showTitleActions: true,
+      theme: DatePickerTheme(
+        headerColor: AppColors.headerBgColor,
+        backgroundColor: AppColors.bodyBgColor,
+        itemStyle: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 18,
+        ),
+        doneStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+        ),
+      ),
+      onConfirm: onConfirm,
+      currentTime: currentTime,
+      locale: LocaleType.en,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    bool valid = dateTo.isAfter(dateFrom) || dateTo == dateFrom;
+    bool changed = dateFrom != widget.item.meta.dateFrom ||
+        dateTo != widget.item.meta.dateTo;
+
+    return Container(
+      height: 150,
+      color: AppColors.bodyBgColor,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: <Widget>[
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  child: Text(
+                    'Date from: ',
+                    textAlign: TextAlign.end,
+                    style: labelStyleLarger,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    showDatePicker(
+                      onConfirm: (DateTime date) {
+                        setState(() {
+                          dateFrom = date;
+                        });
+                      },
+                      currentTime: dateFrom,
+                    );
+                  },
+                  child: Text(
+                    df.format(dateFrom),
+                    style: textStyleLarger,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(
+              height: 8,
+            ),
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  child: Text(
+                    'Date to:',
+                    textAlign: TextAlign.end,
+                    style: labelStyleLarger,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    showDatePicker(
+                      onConfirm: (DateTime date) {
+                        setState(() {
+                          dateTo = date;
+                        });
+                      },
+                      currentTime: dateTo,
+                    );
+                  },
+                  child: Text(
+                    df.format(dateTo),
+                    style: textStyleLarger,
+                  ),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Visibility(
+                    visible: valid && changed,
+                    child: TextButton(
+                      onPressed: () async {
+                        await context
+                            .read<PersistenceCubit>()
+                            .updateJournalEntityDate(
+                              widget.item,
+                              dateFrom: dateFrom,
+                              dateTo: dateTo,
+                            );
+                        Navigator.pop(context);
+                      },
+                      child: Text(
+                        'SAVE',
+                        style: textStyleLarger,
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible: !valid,
+                    child: Text(
+                      'Invalid Date Range',
+                      style: textStyleLarger.copyWith(color: AppColors.error),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -46,10 +46,6 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
     super.initState();
     stream = _db.watchEntityById(widget.item.meta.id);
 
-    stream.listen((event) {
-      debugPrint(event.toString());
-    });
-
     getApplicationDocumentsDirectory().then((value) {
       setState(() {
         docDir = value;

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -157,7 +158,33 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             TextButton(
-              onPressed: () {},
+              onPressed: () {
+                DatePicker.showDateTimePicker(
+                  context,
+                  showTitleActions: true,
+                  theme: DatePickerTheme(
+                    headerColor: Colors.orange,
+                    backgroundColor: AppColors.entryBgColor,
+                    itemStyle: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 18),
+                    doneStyle: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                    ),
+                  ),
+                  onChanged: (date) {
+                    print('change $date in time zone ' +
+                        date.timeZoneOffset.inHours.toString());
+                  },
+                  onConfirm: (date) {
+                    print('confirm $date');
+                  },
+                  currentTime: DateTime.now(),
+                  locale: LocaleType.en,
+                );
+              },
               child: Text(df.format(widget.item.meta.dateFrom)),
             ),
             Visibility(

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -1,17 +1,19 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
 import 'package:lotti/widgets/journal/editor_widget.dart';
+import 'package:lotti/widgets/journal/entry_datetime_modal.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:lotti/widgets/misc/map_widget.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
@@ -33,12 +35,20 @@ class EntryDetailWidget extends StatefulWidget {
 }
 
 class _EntryDetailWidgetState extends State<EntryDetailWidget> {
+  final JournalDb _db = getIt<JournalDb>();
+  late Stream<JournalEntity?> stream;
+
   Directory? docDir;
   bool mapVisible = false;
 
   @override
   void initState() {
     super.initState();
+    stream = _db.watchEntityById(widget.item.meta.id);
+
+    stream.listen((event) {
+      debugPrint(event.toString());
+    });
 
     getApplicationDocumentsDirectory().then((value) {
       setState(() {
@@ -49,171 +59,186 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
   @override
   Widget build(BuildContext context) {
-    Geolocation? loc = widget.item.geolocation;
+    return StreamBuilder(
+      stream: stream,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<JournalEntity?> snapshot,
+      ) {
+        JournalEntity? journalEntity = snapshot.data;
 
-    return Column(
-      children: <Widget>[
-        widget.item.maybeMap(
-          journalAudio: (JournalAudio audio) {
-            QuillController _controller =
-                makeController(serializedQuill: audio.entryText?.quill);
+        if (journalEntity == null) {
+          return Container();
+        }
 
-            void saveText() {
-              EntryText entryText = entryTextFromController(_controller);
+        Geolocation? loc = journalEntity.geolocation;
 
-              context
-                  .read<PersistenceCubit>()
-                  .updateJournalEntityText(widget.item, entryText);
-            }
+        return Column(
+          children: <Widget>[
+            journalEntity.maybeMap(
+              journalAudio: (JournalAudio audio) {
+                QuillController _controller =
+                    makeController(serializedQuill: audio.entryText?.quill);
 
-            return Column(
-              children: [
-                EditorWidget(
-                  controller: _controller,
-                  height: 240,
-                  saveFn: saveText,
-                ),
-                const AudioPlayerWidget(),
-              ],
-            );
-          },
-          journalImage: (JournalImage image) {
-            QuillController _controller =
-                makeController(serializedQuill: image.entryText?.quill);
+                void saveText() {
+                  EntryText entryText = entryTextFromController(_controller);
 
-            void saveText() {
-              EntryText entryText = entryTextFromController(_controller);
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntityText(journalEntity, entryText);
+                }
 
-              context
-                  .read<PersistenceCubit>()
-                  .updateJournalEntityText(widget.item, entryText);
-            }
+                return Column(
+                  children: [
+                    EditorWidget(
+                      controller: _controller,
+                      height: 240,
+                      saveFn: saveText,
+                    ),
+                    const AudioPlayerWidget(),
+                  ],
+                );
+              },
+              journalImage: (JournalImage image) {
+                QuillController _controller =
+                    makeController(serializedQuill: image.entryText?.quill);
 
-            return Column(
-              children: [
-                EntryImageWidget(
-                  journalImage: image,
-                  height: 400,
-                ),
-                EditorWidget(
+                void saveText() {
+                  EntryText entryText = entryTextFromController(_controller);
+
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntityText(journalEntity, entryText);
+                }
+
+                return Column(
+                  children: [
+                    EntryImageWidget(
+                      journalImage: image,
+                      height: 400,
+                    ),
+                    EditorWidget(
+                      controller: _controller,
+                      readOnly: widget.readOnly,
+                      saveFn: saveText,
+                    ),
+                  ],
+                );
+              },
+              journalEntry: (JournalEntry journalEntry) {
+                QuillController _controller = makeController(
+                    serializedQuill: journalEntry.entryText.quill);
+
+                void saveText() {
+                  context.read<PersistenceCubit>().updateJournalEntityText(
+                      journalEntity, entryTextFromController(_controller));
+                }
+
+                return EditorWidget(
                   controller: _controller,
                   readOnly: widget.readOnly,
                   saveFn: saveText,
-                ),
-              ],
-            );
-          },
-          journalEntry: (JournalEntry journalEntry) {
-            QuillController _controller =
-                makeController(serializedQuill: journalEntry.entryText.quill);
-
-            void saveText() {
-              context.read<PersistenceCubit>().updateJournalEntityText(
-                  widget.item, entryTextFromController(_controller));
-            }
-
-            return EditorWidget(
-              controller: _controller,
-              readOnly: widget.readOnly,
-              saveFn: saveText,
-            );
-          },
-          measurement: (MeasurementEntry entry) {
-            QuillController _controller =
-                makeController(serializedQuill: entry.entryText?.quill);
-
-            void saveText() {
-              context.read<PersistenceCubit>().updateJournalEntityText(
-                  widget.item, entryTextFromController(_controller));
-            }
-
-            return EditorWidget(
-              controller: _controller,
-              readOnly: widget.readOnly,
-              saveFn: saveText,
-            );
-          },
-          survey: (SurveyEntry surveyEntry) => SurveySummaryWidget(surveyEntry),
-          quantitative: (qe) => qe.data.map(
-            cumulativeQuantityData: (qd) => Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: InfoText(
-                'End: ${df.format(qe.meta.dateTo)}'
-                '\n${formatType(qd.dataType)}: '
-                '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
-              ),
-            ),
-            discreteQuantityData: (qd) => Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: InfoText(
-                'End: ${df.format(qe.meta.dateTo)}'
-                '\n${formatType(qd.dataType)}: '
-                '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
-              ),
-            ),
-          ),
-          orElse: () => Container(),
-        ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            TextButton(
-              onPressed: () {
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.vertical(
-                      top: Radius.circular(16),
-                    ),
-                  ),
-                  clipBehavior: Clip.antiAliasWithSaveLayer,
-                  builder: (BuildContext context) {
-                    return EntryDateTimeModal(
-                      item: widget.item,
-                    );
-                  },
                 );
               },
-              child: Text(
-                df.format(widget.item.meta.dateFrom),
-                style: textStyle,
-              ),
-            ),
-            Visibility(
-              visible: loc != null && loc.longitude != 0,
-              child: TextButton(
-                onPressed: () => setState(() {
-                  mapVisible = !mapVisible;
-                }),
-                child: Text(
-                  '📍 ${formatLatLon(loc?.latitude)}, '
-                  '${formatLatLon(loc?.longitude)}',
-                  style: textStyle,
+              measurement: (MeasurementEntry entry) {
+                QuillController _controller =
+                    makeController(serializedQuill: entry.entryText?.quill);
+
+                void saveText() {
+                  context.read<PersistenceCubit>().updateJournalEntityText(
+                      journalEntity, entryTextFromController(_controller));
+                }
+
+                return EditorWidget(
+                  controller: _controller,
+                  readOnly: widget.readOnly,
+                  saveFn: saveText,
+                );
+              },
+              survey: (SurveyEntry surveyEntry) =>
+                  SurveySummaryWidget(surveyEntry),
+              quantitative: (qe) => qe.data.map(
+                cumulativeQuantityData: (qd) => Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: InfoText(
+                    'End: ${df.format(qe.meta.dateTo)}'
+                    '\n${formatType(qd.dataType)}: '
+                    '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+                  ),
+                ),
+                discreteQuantityData: (qd) => Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: InfoText(
+                    'End: ${df.format(qe.meta.dateTo)}'
+                    '\n${formatType(qd.dataType)}: '
+                    '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+                  ),
                 ),
               ),
+              orElse: () => Container(),
             ),
-            IconButton(
-              icon: const Icon(MdiIcons.trashCanOutline),
-              iconSize: 24,
-              tooltip: 'Delete',
-              color: AppColors.appBarFgColor,
-              onPressed: () {
-                context
-                    .read<PersistenceCubit>()
-                    .deleteJournalEntity(widget.item);
-                Navigator.pop(context);
-              },
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    showModalBottomSheet<void>(
+                      context: context,
+                      isScrollControlled: true,
+                      shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.vertical(
+                          top: Radius.circular(16),
+                        ),
+                      ),
+                      clipBehavior: Clip.antiAliasWithSaveLayer,
+                      builder: (BuildContext context) {
+                        return EntryDateTimeModal(
+                          item: journalEntity,
+                        );
+                      },
+                    );
+                  },
+                  child: Text(
+                    df.format(journalEntity.meta.dateFrom),
+                    style: textStyle,
+                  ),
+                ),
+                Visibility(
+                  visible: loc != null && loc.longitude != 0,
+                  child: TextButton(
+                    onPressed: () => setState(() {
+                      mapVisible = !mapVisible;
+                    }),
+                    child: Text(
+                      '📍 ${formatLatLon(loc?.latitude)}, '
+                      '${formatLatLon(loc?.longitude)}',
+                      style: textStyle,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(MdiIcons.trashCanOutline),
+                  iconSize: 24,
+                  tooltip: 'Delete',
+                  color: AppColors.appBarFgColor,
+                  onPressed: () {
+                    context
+                        .read<PersistenceCubit>()
+                        .deleteJournalEntity(journalEntity);
+                    Navigator.pop(context);
+                  },
+                ),
+              ],
+            ),
+            Visibility(
+              visible: mapVisible,
+              child: MapWidget(
+                geolocation: journalEntity.geolocation,
+              ),
             ),
           ],
-        ),
-        Visibility(
-          visible: mapVisible,
-          child: MapWidget(
-            geolocation: widget.item.geolocation,
-          ),
-        ),
-      ],
+        );
+      },
     );
   }
 }
@@ -268,168 +293,5 @@ class _EntryImageWidgetState extends State<EntryImageWidget> {
     } else {
       return Container();
     }
-  }
-}
-
-class EntryDateTimeModal extends StatefulWidget {
-  final JournalEntity item;
-  final bool readOnly;
-  const EntryDateTimeModal({
-    Key? key,
-    required this.item,
-    this.readOnly = false,
-  }) : super(key: key);
-
-  @override
-  _EntryDateTimeModalState createState() => _EntryDateTimeModalState();
-}
-
-class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
-  late DateTime dateFrom;
-  late DateTime dateTo;
-
-  @override
-  void initState() {
-    super.initState();
-    dateFrom = widget.item.meta.dateFrom;
-    dateTo = widget.item.meta.dateTo;
-  }
-
-  void showDatePicker({
-    required Function(DateTime) onConfirm,
-    required DateTime currentTime,
-  }) {
-    DatePicker.showDateTimePicker(
-      context,
-      showTitleActions: true,
-      theme: DatePickerTheme(
-        headerColor: AppColors.headerBgColor,
-        backgroundColor: AppColors.bodyBgColor,
-        itemStyle: const TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
-          fontSize: 18,
-        ),
-        doneStyle: const TextStyle(
-          color: Colors.white,
-          fontSize: 16,
-        ),
-      ),
-      onConfirm: onConfirm,
-      currentTime: currentTime,
-      locale: LocaleType.en,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    bool valid = dateTo.isAfter(dateFrom) || dateTo == dateFrom;
-    bool changed = dateFrom != widget.item.meta.dateFrom ||
-        dateTo != widget.item.meta.dateTo;
-
-    return Container(
-      height: 150,
-      color: AppColors.bodyBgColor,
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: <Widget>[
-            Row(
-              children: [
-                SizedBox(
-                  width: 120,
-                  child: Text(
-                    'Date from: ',
-                    textAlign: TextAlign.end,
-                    style: labelStyleLarger,
-                  ),
-                ),
-                TextButton(
-                  onPressed: () {
-                    showDatePicker(
-                      onConfirm: (DateTime date) {
-                        setState(() {
-                          dateFrom = date;
-                        });
-                      },
-                      currentTime: dateFrom,
-                    );
-                  },
-                  child: Text(
-                    df.format(dateFrom),
-                    style: textStyleLarger,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(
-              height: 8,
-            ),
-            Row(
-              children: [
-                SizedBox(
-                  width: 120,
-                  child: Text(
-                    'Date to:',
-                    textAlign: TextAlign.end,
-                    style: labelStyleLarger,
-                  ),
-                ),
-                TextButton(
-                  onPressed: () {
-                    showDatePicker(
-                      onConfirm: (DateTime date) {
-                        setState(() {
-                          dateTo = date;
-                        });
-                      },
-                      currentTime: dateTo,
-                    );
-                  },
-                  child: Text(
-                    df.format(dateTo),
-                    style: textStyleLarger,
-                  ),
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  Visibility(
-                    visible: valid && changed,
-                    child: TextButton(
-                      onPressed: () async {
-                        await context
-                            .read<PersistenceCubit>()
-                            .updateJournalEntityDate(
-                              widget.item,
-                              dateFrom: dateFrom,
-                              dateTo: dateTo,
-                            );
-                        Navigator.pop(context);
-                      },
-                      child: Text(
-                        'SAVE',
-                        style: textStyleLarger,
-                      ),
-                    ),
-                  ),
-                  Visibility(
-                    visible: !valid,
-                    child: Text(
-                      'Invalid Date Range',
-                      style: textStyleLarger.copyWith(color: AppColors.error),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -5,6 +5,7 @@ import 'package:lotti/blocs/audio/player_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/measurables.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_detail_route.dart';
 import 'package:lotti/widgets/journal/entry_detail_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
@@ -170,7 +171,7 @@ class JournalCard extends StatelessWidget {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (BuildContext context) {
-                  return DetailRoute(
+                  return EntryDetailRoute(
                     item: item,
                     index: index,
                   );
@@ -181,44 +182,5 @@ class JournalCard extends StatelessWidget {
         ),
       );
     });
-  }
-}
-
-class DetailRoute extends StatelessWidget {
-  const DetailRoute({
-    Key? key,
-    required this.item,
-    required this.index,
-  }) : super(key: key);
-
-  final int index;
-  final JournalEntity item;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.bodyBgColor,
-      appBar: AppBar(
-        title: Text(
-          df.format(item.meta.dateFrom),
-          style: TextStyle(
-            color: AppColors.entryBgColor,
-            fontFamily: 'Oswald',
-          ),
-        ),
-        backgroundColor: AppColors.headerBgColor,
-      ),
-      body: Container(
-        color: AppColors.bodyBgColor,
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(context).viewInsets.bottom,
-        ),
-        child: SingleChildScrollView(
-          child: EntryDetailWidget(
-            item: item,
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lotti/lib/widgets/pages/add/new_measurement_page.dart
+++ b/lotti/lib/widgets/pages/add/new_measurement_page.dart
@@ -32,17 +32,6 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
 
   String description = '';
 
-  TextStyle inputStyle = TextStyle(
-    color: AppColors.entryTextColor,
-    fontWeight: FontWeight.w300,
-    fontSize: 18.0,
-  );
-
-  TextStyle labelStyle = TextStyle(
-    color: AppColors.entryTextColor,
-    fontSize: 16.0,
-  );
-
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<PersistenceCubit, PersistenceState>(

--- a/lotti/lib/widgets/pages/add/new_measurement_page.dart
+++ b/lotti/lib/widgets/pages/add/new_measurement_page.dart
@@ -32,6 +32,17 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
 
   String description = '';
 
+  TextStyle inputStyle = TextStyle(
+    color: AppColors.entryTextColor,
+    fontWeight: FontWeight.w300,
+    fontSize: 18.0,
+  );
+
+  TextStyle labelStyle = TextStyle(
+    color: AppColors.entryTextColor,
+    fontSize: 16.0,
+  );
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<PersistenceCubit, PersistenceState>(
@@ -105,11 +116,16 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                         child: Column(
                           children: <Widget>[
                             FormBuilderDropdown(
+                              dropdownColor: AppColors.headerBgColor,
                               name: 'type',
-                              decoration: const InputDecoration(
+                              decoration: InputDecoration(
                                 labelText: 'Type',
+                                labelStyle: labelStyle,
                               ),
-                              hint: const Text('Select Measurement Type'),
+                              hint: Text(
+                                'Select Measurement Type',
+                                style: inputStyle,
+                              ),
                               onChanged: (MeasurableDataType? value) {
                                 setState(() {
                                   description = value?.description ?? '';
@@ -121,7 +137,10 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                                   .map((MeasurableDataType item) =>
                                       DropdownMenuItem(
                                         value: item,
-                                        child: Text(item.displayName),
+                                        child: Text(
+                                          item.displayName,
+                                          style: inputStyle,
+                                        ),
                                       ))
                                   .toList(),
                             ),
@@ -132,8 +151,10 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                                 format: DateFormat(
                                     'EEEE, MMMM d, yyyy \'at\' HH:mm'),
                                 inputType: InputType.both,
-                                decoration: const InputDecoration(
+                                style: inputStyle,
+                                decoration: InputDecoration(
                                   labelText: 'Measurement taken',
+                                  labelStyle: labelStyle,
                                 ),
                                 initialValue: DateTime.now(),
                               ),
@@ -142,7 +163,9 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                                 initialValue: '',
                                 decoration: InputDecoration(
                                   labelText: description,
+                                  labelStyle: labelStyle,
                                 ),
+                                style: inputStyle,
                                 name: 'value',
                                 keyboardType:
                                     const TextInputType.numberWithOptions(
@@ -160,40 +183,5 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
         },
       );
     });
-  }
-}
-
-class FormTextField extends StatelessWidget {
-  const FormTextField({
-    Key? key,
-    required this.initialValue,
-    required this.name,
-    required this.labelText,
-    this.keyboardType,
-  }) : super(key: key);
-
-  final String initialValue;
-  final String name;
-  final String labelText;
-  final TextInputType? keyboardType;
-
-  @override
-  Widget build(BuildContext context) {
-    return FormBuilderTextField(
-      name: name,
-      initialValue: initialValue,
-      validator: FormBuilderValidators.required(context),
-      style: TextStyle(
-        color: AppColors.entryTextColor,
-        height: 1.6,
-        fontFamily: 'Lato',
-        fontSize: 24,
-      ),
-      keyboardType: keyboardType,
-      decoration: InputDecoration(
-        labelText: labelText,
-        labelStyle: TextStyle(color: AppColors.entryTextColor, fontSize: 16),
-      ),
-    );
   }
 }

--- a/lotti/macos/Runner/Info.plist
+++ b/lotti/macos/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationUsageDescription</key>
+	<string>Obtain location for journal entries</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Import photos and videos</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -559,6 +559,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  flutter_datetime_picker:
+    dependency: "direct main"
+    description:
+      name: flutter_datetime_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   flutter_dotenv:
     dependency: "direct main"
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.14+200
+version: 0.3.14+201
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.14+199
+version: 0.3.14+200
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.14+198
+version: 0.3.14+199
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.14+202
+version: 0.3.14+203
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.13+197
+version: 0.3.14+198
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -71,6 +71,7 @@ dependencies:
   wechat_assets_picker: ^6.3.0
   yaml: ^3.1.0
   form_builder_validators: ^7.2.0
+  flutter_datetime_picker: ^1.5.1
 
 dev_dependencies:
   flutter_test:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.14+201
+version: 0.3.14+202
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a bottom modal/toaster for setting the start and end dates of the entry. This functionality is accessible by tapping the entry date in the footer of the details page.