### PR TITLE
Ignore images as long as import flag is set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.367",
+  "version": "0.6.368",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.367",
+  "version": "0.6.368",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/import/images.cljs
+++ b/src/cljs/meins/electron/main/import/images.cljs
@@ -12,25 +12,7 @@
 
 (def image-path-atom (atom ""))
 
-(defn convert-image-entry [data]
-  (let [ts (get data "timestamp")
-        text (str (h/format-time ts) " Image")
-        geolocation (get data "geolocation")
-        entry {:timestamp  ts
-               :md         text
-               :text       text
-               :mentions   #{}
-               :utc-offset 0
-               :img_file   (s/replace (get data "imageFile") "HEIC" "JPG")
-               :timezone   (get data "timezone")
-               :tags       #{"#photo" "#import"}
-               :perm_tags  #{"#photo"}
-               :longitude  (get geolocation "longitude")
-               :latitude   (get geolocation "latitude")
-               :vclock     (get data "vectorClock")}]
-    entry))
-
-(defn convert-new-image-entry [json]
+(defn convert-image-entry [json]
   (let [meta-data (get json "meta")
         date-from (get meta-data "dateFrom")
         entry-text-object (get json "entryText")
@@ -52,14 +34,15 @@
                :longitude  (get geolocation "longitude")
                :latitude   (get geolocation "latitude")
                :vclock     (get meta-data "vectorClock")}]
-    entry))
+    (when (not= "import" (get meta-data "flag"))
+      entry)))
 
 (defn import-image-files [path put-fn]
   (let [files (sync (str path "/images/**/*.+(JPG|JPEG|jpg|jpeg).json"))]
     (doseq [json-file files]
       (when-not (s/includes? json-file "trash")
         (let [data (h/parse-json json-file)
-              entry (convert-new-image-entry data)
+              entry (convert-image-entry data)
               file (str/replace json-file ".json" "")
               img-file (:img_file entry)
               img-file-path (str @image-path-atom "/" img-file)]

--- a/src/test/meins/shared/import_test.cljs
+++ b/src/test/meins/shared/import_test.cljs
@@ -124,6 +124,33 @@
     (testing "Parsed entry is valid"
       (s/valid? :meins.entry/spec import-flag-removed))))
 
+(deftest import-flag-image-test
+  (let [flagged-import (ii/convert-image-entry
+                         (h/parse-json
+                           (test-data-file "flagged_import.JPG.json")))
+        import-flag-removed (ii/convert-image-entry
+                              (h/parse-json
+                                (test-data-file "flagged_import_removed.JPG.json")))]
+    (testing "Entry with import flag is ignored"
+      (is (nil? flagged-import)))
+    (testing "Entry is converted after removing the flag"
+      (is (= import-flag-removed
+             {:mentions   #{}
+              :tags       #{"#photo" "#import"}
+              :timezone   "Europe/Berlin"
+              :utc-offset 0
+              :perm_tags  #{"#photo"}
+              :longitude  nil
+              :vclock     {"1f9af04b-9cbe-454e-9937-a3729d2f7371" 44
+                           "f44742d5-972f-4a6f-ba4c-03152bb4527b" 107}
+              :latitude   nil
+              :timestamp  1641086895000
+              :img_file   "05019F5D-25FD-4449-84E7-41B9362189D6.IMG_8959.JPG"
+              :text       "test\n"
+              :md         "test\n"})))
+    (testing "Parsed entry is valid"
+      (s/valid? :meins.entry/spec import-flag-removed))))
+
 (def expected-text-image (str (h/format-time 1636319781000) " Image"))
 (def new-image-test-entry
   {:mentions   #{}
@@ -142,7 +169,7 @@
 (deftest read-new-image-entry-test
   (let [json-file (test-data-file "test.HEIC.json")
         data (h/parse-json json-file)
-        entry (ii/convert-new-image-entry data)]
+        entry (ii/convert-image-entry data)]
     (testing "JSON is parsed correctly"
       (is (= entry new-image-test-entry)))
     (testing "Parsed entry is valid"

--- a/src/test/meins/shared/test-files/flagged_import.JPG.json
+++ b/src/test/meins/shared/test-files/flagged_import.JPG.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "id": "124a090f-a171-519b-b389-66e720d33507",
+    "createdAt": "2022-01-02T01:28:24.430199",
+    "updatedAt": "2022-01-02T01:28:24.430199",
+    "dateFrom": "2022-01-02T01:28:15.000",
+    "dateTo": "2022-01-02T01:28:15.000",
+    "utcOffset": 60,
+    "timezone": "Europe/Berlin",
+    "vectorClock": {
+      "1f9af04b-9cbe-454e-9937-a3729d2f7371": 44
+    },
+    "deletedAt": null,
+    "flag": "import",
+    "starred": null
+  },
+  "data": {
+    "capturedAt": "2022-01-02T01:28:15.000",
+    "imageId": "05019F5D-25FD-4449-84E7-41B9362189D6/L0/001",
+    "imageFile": "05019F5D-25FD-4449-84E7-41B9362189D6.IMG_8959.JPG",
+    "imageDirectory": "/images/2022-01-02/",
+    "geolocation": null
+  },
+  "entryText": null,
+  "geolocation": null,
+  "runtimeType": "journalImage"
+}

--- a/src/test/meins/shared/test-files/flagged_import_removed.JPG.json
+++ b/src/test/meins/shared/test-files/flagged_import_removed.JPG.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "id": "124a090f-a171-519b-b389-66e720d33507",
+    "createdAt": "2022-01-02T01:28:24.430199",
+    "updatedAt": "2022-01-02T01:30:25.884002",
+    "dateFrom": "2022-01-02T01:28:15.000",
+    "dateTo": "2022-01-02T01:28:15.000",
+    "utcOffset": 60,
+    "timezone": "Europe/Berlin",
+    "vectorClock": {
+      "1f9af04b-9cbe-454e-9937-a3729d2f7371": 44,
+      "f44742d5-972f-4a6f-ba4c-03152bb4527b": 107
+    },
+    "deletedAt": null,
+    "flag": "none",
+    "starred": null
+  },
+  "data": {
+    "capturedAt": "2022-01-02T01:28:15.000",
+    "imageId": "05019F5D-25FD-4449-84E7-41B9362189D6/L0/001",
+    "imageFile": "05019F5D-25FD-4449-84E7-41B9362189D6.IMG_8959.JPG",
+    "imageDirectory": "/images/2022-01-02/",
+    "geolocation": null
+  },
+  "entryText": {
+    "plainText": "test\n",
+    "geolocation": null,
+    "markdown": "test\n",
+    "quill": "[{\"insert\":\"test\\n\"}]"
+  },
+  "geolocation": null,
+  "runtimeType": "journalImage"
+}


### PR DESCRIPTION
This PR adds ignoring of photos flagged as `import`. Similar to #637 but for photos, not audio.