### PR TITLE
Log db & remove Sentry

### DIFF
--- a/lotti/lib/blocs/audio/player_cubit.dart
+++ b/lotti/lib/blocs/audio/player_cubit.dart
@@ -2,11 +2,13 @@ import 'package:bloc/bloc.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:lotti/blocs/audio/player_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/utils/audio_utils.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 class AudioPlayerCubit extends Cubit<AudioPlayerState> {
   final AudioPlayer _audioPlayer = AudioPlayer();
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
 
   AudioPlayerCubit()
       : super(AudioPlayerState(
@@ -48,7 +50,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         emit(newState.copyWith(totalDuration: totalDuration));
       }
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -59,7 +61,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
       await _audioPlayer.seek(state.pausedAt);
       emit(state.copyWith(status: AudioPlayerStatus.playing));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -71,7 +73,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         progress: const Duration(minutes: 0),
       ));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -83,7 +85,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         pausedAt: newPosition,
       ));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -92,7 +94,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
       await _audioPlayer.setSpeed(speed);
       emit(state.copyWith(speed: speed));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -104,7 +106,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         pausedAt: state.progress,
       ));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -118,7 +120,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         pausedAt: newPosition,
       ));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -132,7 +134,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         pausedAt: newPosition,
       ));
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 

--- a/lotti/lib/blocs/audio/recorder_cubit.dart
+++ b/lotti/lib/blocs/audio/recorder_cubit.dart
@@ -8,11 +8,12 @@ import 'package:lotti/blocs/audio/recorder_state.dart';
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/audio_note.dart';
 import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/location.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 AudioRecorderState initialState = AudioRecorderState(
   status: AudioRecorderStatus.initializing,
@@ -22,6 +23,7 @@ AudioRecorderState initialState = AudioRecorderState(
 
 class AudioRecorderCubit extends Cubit<AudioRecorderState> {
   late final PersistenceCubit _persistenceCubit;
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
 
   final FlutterSoundRecorder? _myRecorder = FlutterSoundRecorder();
   AudioNote? _audioNote;
@@ -49,7 +51,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         updateProgress(event);
       });
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -75,7 +77,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         }
       });
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -115,7 +117,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         emit(state.copyWith(status: AudioRecorderStatus.recording));
       });
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 
@@ -131,7 +133,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         _persistenceCubit.createAudioEntry(audioNote);
       }
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
   }
 

--- a/lotti/lib/blocs/journal/health_cubit.dart
+++ b/lotti/lib/blocs/journal/health_cubit.dart
@@ -9,7 +9,8 @@ import 'package:health/health.dart';
 import 'package:lotti/blocs/journal/health_state.dart';
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/health.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 
 class HealthCubit extends Cubit<HealthState> {
   late final PersistenceCubit _persistenceCubit;
@@ -45,8 +46,10 @@ class HealthCubit extends Cubit<HealthState> {
     DateTime now = DateTime.now();
     DateTime dateToOrNow = dateTo.isAfter(now) ? now : dateTo;
 
+    final InsightsDb _insightsDb = getIt<InsightsDb>();
     final transaction =
-        Sentry.startTransaction('getActivityHealthData()', 'task');
+        _insightsDb.startTransaction('getActivityHealthData()', 'task');
+
     final flutterHealthFit = FlutterHealthFit();
     final bool isAuthorized = await FlutterHealthFit().authorize(true);
     final bool isAnyAuth = await flutterHealthFit.isAnyPermissionAuthorized();
@@ -90,7 +93,10 @@ class HealthCubit extends Cubit<HealthState> {
     required DateTime dateFrom,
     required DateTime dateTo,
   }) async {
-    final transaction = Sentry.startTransaction('fetchHealthData()', 'task');
+    final InsightsDb _insightsDb = getIt<InsightsDb>();
+
+    final transaction =
+        _insightsDb.startTransaction('fetchHealthData()', 'task');
     HealthFactory health = HealthFactory();
     bool accessWasGranted = await health.requestAuthorization(types);
 

--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -20,7 +20,6 @@ import 'package:lotti/main.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/sync/vector_clock.dart';
 import 'package:lotti/utils/file_utils.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:uuid/uuid.dart';
 
 class PersistenceCubit extends Cubit<PersistenceState> {
@@ -47,7 +46,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
   Future<bool> createQuantitativeEntry(QuantitativeData data) async {
     final transaction =
-        Sentry.startTransaction('createQuantitativeEntry()', 'task');
+        _insightsDb.startTransaction('createQuantitativeEntry()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock();
@@ -83,7 +82,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   Future<bool> createSurveyEntry({
     required SurveyData data,
   }) async {
-    final transaction = Sentry.startTransaction('createSurveyEntry()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('createSurveyEntry()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock();
@@ -122,7 +122,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     required MeasurementData data,
   }) async {
     final transaction =
-        Sentry.startTransaction('createMeasurementEntry()', 'task');
+        _insightsDb.startTransaction('createMeasurementEntry()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock();
@@ -158,7 +158,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   }
 
   Future<bool> createImageEntry(ImageData imageData) async {
-    final transaction = Sentry.startTransaction('createImageEntry()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('createImageEntry()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock();
@@ -194,7 +195,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   }
 
   Future<bool> createAudioEntry(AudioNote audioNote) async {
-    final transaction = Sentry.startTransaction('createImageEntry()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('createImageEntry()', 'task');
     try {
       AudioData audioData = AudioData(
         audioDirectory: audioNote.audioDirectory,
@@ -238,7 +240,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   }
 
   Future<bool> createTextEntry(EntryText entryText) async {
-    final transaction = Sentry.startTransaction('createTextEntry()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('createTextEntry()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock();
@@ -273,7 +276,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
   Future<bool?> createDbEntity(JournalEntity journalEntity,
       {bool enqueueSync = false}) async {
-    final transaction = Sentry.startTransaction('createDbEntity()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('createDbEntity()', 'task');
     try {
       int? res = await _journalDb.addJournalEntity(journalEntity);
       bool saved = (res != 0);
@@ -298,7 +302,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     EntryText entryText,
   ) async {
     final transaction =
-        Sentry.startTransaction('updateJournalEntity()', 'task');
+        _insightsDb.startTransaction('updateJournalEntity()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock(
@@ -367,7 +371,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     required DateTime dateTo,
   }) async {
     final transaction =
-        Sentry.startTransaction('updateJournalEntity()', 'task');
+        _insightsDb.startTransaction('updateJournalEntity()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock(
@@ -397,7 +401,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     JournalEntity journalEntity,
   ) async {
     final transaction =
-        Sentry.startTransaction('updateJournalEntity()', 'task');
+        _insightsDb.startTransaction('updateJournalEntity()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock(
@@ -423,7 +427,8 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     JournalEntity journalEntity, {
     bool enqueueSync = false,
   }) async {
-    final transaction = Sentry.startTransaction('updateDbEntity()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('updateDbEntity()', 'task');
     try {
       int res = await _journalDb.updateJournalEntity(journalEntity);
       debugPrint('updateDbEntity res $res');

--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -91,7 +91,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
       Geolocation? geolocation = await location.getCurrentGeoLocation().timeout(
             const Duration(seconds: 5),
-            onTimeout: () => null, // TODO: report timeout in Sentry
+            onTimeout: () => null, // TODO: report timeout in Insights
           );
 
       JournalEntity journalEntity = JournalEntity.survey(
@@ -130,7 +130,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
       Geolocation? geolocation = await location.getCurrentGeoLocation().timeout(
             const Duration(seconds: 5),
-            onTimeout: () => null, // TODO: report timeout in Sentry
+            onTimeout: () => null, // TODO: report timeout in Insights
           );
 
       JournalEntity journalEntity = JournalEntity.measurement(

--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -14,6 +14,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/measurables.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/location.dart';
 import 'package:lotti/main.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -26,6 +27,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   late final OutboxCubit _outboundQueueCubit;
   final JournalDb _journalDb = getIt<JournalDb>();
   late final VectorClockService _vectorClockService;
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
 
   final uuid = const Uuid();
   DeviceLocation location = DeviceLocation();
@@ -71,7 +73,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       );
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -109,7 +111,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -148,7 +150,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -184,7 +186,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       );
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -228,7 +230,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       );
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -262,7 +264,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       );
       await createDbEntity(journalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -286,7 +288,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       await transaction.finish();
       return saved;
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
       debugPrint('Exception $exception');
     }
   }
@@ -352,7 +354,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
         await updateDbEntity(newEntry, enqueueSync: true);
       }
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -384,7 +386,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
 
       await updateDbEntity(newJournalEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -410,7 +412,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       JournalEntity newEntity = journalEntity.copyWith(meta: newMeta);
       await updateDbEntity(newEntity, enqueueSync: true);
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
     }
 
     await transaction.finish();
@@ -436,7 +438,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       await transaction.finish();
       return true;
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
       debugPrint('Exception $exception');
     }
   }

--- a/lotti/lib/blocs/sync/imap/imap_client.dart
+++ b/lotti/lib/blocs/sync/imap/imap_client.dart
@@ -3,13 +3,13 @@ import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/main.dart';
 import 'package:lotti/services/sync_config_service.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 Future<ImapClient?> createImapClient() async {
   final SyncConfigService _syncConfigService = getIt<SyncConfigService>();
   final InsightsDb _insightsDb = getIt<InsightsDb>();
   SyncConfig? syncConfig = await _syncConfigService.getSyncConfig();
-  final transaction = Sentry.startTransaction('createImapClient()', 'task');
+  final transaction =
+      _insightsDb.startTransaction('createImapClient()', 'task');
 
   try {
     if (syncConfig != null) {

--- a/lotti/lib/blocs/sync/imap/imap_client.dart
+++ b/lotti/lib/blocs/sync/imap/imap_client.dart
@@ -33,7 +33,7 @@ Future<ImapClient?> createImapClient() async {
       throw Exception('missing IMAP config');
     }
   } catch (e, stackTrace) {
-    await Sentry.captureException(e, stackTrace: stackTrace);
+    await _insightsDb.captureException(e, stackTrace: stackTrace);
   }
   await transaction.finish();
 }

--- a/lotti/lib/blocs/sync/imap/imap_client.dart
+++ b/lotti/lib/blocs/sync/imap/imap_client.dart
@@ -26,9 +26,6 @@ Future<ImapClient?> createImapClient() async {
 
       imapClient.eventBus.on<ImapEvent>().listen((ImapEvent imapEvent) async {
         _insightsDb.captureEvent(imapEvent, domain: 'IMAP_CLIENT');
-        await Sentry.captureEvent(
-            SentryEvent(message: SentryMessage(imapEvent.toString())),
-            withScope: (Scope scope) => scope.level = SentryLevel.info);
       });
 
       return imapClient;

--- a/lotti/lib/blocs/sync/imap/inbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_cubit.dart
@@ -71,7 +71,8 @@ class InboxImapCubit extends Cubit<ImapState> {
   }
 
   Future<void> processMessage(MimeMessage message) async {
-    final transaction = Sentry.startTransaction('processMessage()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('processMessage()', 'task');
     try {
       String? encryptedMessage = readMessage(message);
       SyncConfig? syncConfig = await _syncConfigService.getSyncConfig();
@@ -144,7 +145,7 @@ class InboxImapCubit extends Cubit<ImapState> {
   }
 
   Future<void> _fetchInbox() async {
-    final transaction = Sentry.startTransaction('_fetchInbox()', 'task');
+    final transaction = _insightsDb.startTransaction('_fetchInbox()', 'task');
     ImapClient? imapClient;
 
     _insightsDb.captureEvent('_fetchInbox()', domain: 'INBOX_CUBIT');
@@ -218,7 +219,7 @@ class InboxImapCubit extends Cubit<ImapState> {
     int? uid,
     ImapClient? imapClient,
   }) async {
-    final transaction = Sentry.startTransaction('_fetchByUid()', 'task');
+    final transaction = _insightsDb.startTransaction('_fetchByUid()', 'task');
     if (uid != null) {
       try {
         if (imapClient != null) {

--- a/lotti/lib/blocs/sync/imap/inbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_cubit.dart
@@ -29,7 +29,6 @@ import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:mutex/mutex.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 class InboxImapCubit extends Cubit<ImapState> {
   final SyncConfigService _syncConfigService = getIt<SyncConfigService>();
@@ -281,12 +280,10 @@ class InboxImapCubit extends Cubit<ImapState> {
 
           await _observingClient!.resume();
 
-          _insightsDb.captureEvent(SentryEvent(
-            message: SentryMessage(
-              'isConnected: ${_observingClient!.isConnected} '
-              'isPolling: ${_observingClient!.isPolling()}',
-            ),
-          ));
+          _insightsDb.captureEvent(
+            'isConnected: ${_observingClient!.isConnected} '
+            'isPolling: ${_observingClient!.isPolling()}',
+          );
         });
 
         _observingClient!.startPolling();

--- a/lotti/lib/blocs/sync/imap/inbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_cubit.dart
@@ -120,7 +120,7 @@ class InboxImapCubit extends Cubit<ImapState> {
         throw Exception('missing IMAP config');
       }
     } catch (e, stackTrace) {
-      await Sentry.captureException(e, stackTrace: stackTrace);
+      await _insightsDb.captureException(e, stackTrace: stackTrace);
       emit(ImapState.failed(error: 'failed: $e ${e.toString()}'));
     }
 
@@ -196,7 +196,7 @@ class InboxImapCubit extends Cubit<ImapState> {
         debugPrint('High level API failed with $e');
 
         emit(ImapState.failed(error: 'failed: $e ${e.details} ${e.message}'));
-        await Sentry.captureException(e);
+        await _insightsDb.captureException(e);
       } catch (e) {
         debugPrint('Exception $e');
         emit(ImapState.failed(error: 'failed: $e ${e.toString()}'));
@@ -235,10 +235,10 @@ class InboxImapCubit extends Cubit<ImapState> {
         }
       } on MailException catch (e) {
         debugPrint('High level API failed with $e');
-        await Sentry.captureException(e);
+        await _insightsDb.captureException(e);
         emit(ImapState.failed(error: 'failed: $e ${e.details}'));
       } catch (e, stackTrace) {
-        await Sentry.captureException(e, stackTrace: stackTrace);
+        await _insightsDb.captureException(e, stackTrace: stackTrace);
         emit(ImapState.failed(error: 'failed: $e ${e.toString()}'));
       } finally {}
     }
@@ -292,10 +292,10 @@ class InboxImapCubit extends Cubit<ImapState> {
       }
     } on MailException catch (e) {
       debugPrint('High level API failed with $e');
-      await Sentry.captureException(e);
+      await _insightsDb.captureException(e);
       emit(ImapState.failed(error: 'failed: $e ${e.details}'));
     } catch (e, stackTrace) {
-      await Sentry.captureException(e, stackTrace: stackTrace);
+      await _insightsDb.captureException(e, stackTrace: stackTrace);
       emit(ImapState.failed(error: 'failed: $e ${e.toString()}'));
     }
   }

--- a/lotti/lib/blocs/sync/imap/inbox_save_attachments.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_save_attachments.dart
@@ -5,17 +5,21 @@ import 'package:enough_mail/enough_mail.dart';
 import 'package:enough_mail/mime_message.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/sync/encryption.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 Future<void> saveAudioAttachment(
   MimeMessage message,
   JournalAudio? journalAudio,
   String? b64Secret,
 ) async {
-  final transaction = Sentry.startTransaction('saveAudioAttachment()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+
+  final transaction =
+      _insightsDb.startTransaction('saveAudioAttachment()', 'task');
   final attachments =
       message.findContentInfo(disposition: ContentDisposition.attachment);
 
@@ -41,7 +45,9 @@ Future<void> saveImageAttachment(
   JournalImage? journalImage,
   String? b64Secret,
 ) async {
-  final transaction = Sentry.startTransaction('saveImageAttachment()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+  final transaction =
+      _insightsDb.startTransaction('saveImageAttachment()', 'task');
   final attachments =
       message.findContentInfo(disposition: ContentDisposition.attachment);
 

--- a/lotti/lib/blocs/sync/imap/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_cubit.dart
@@ -8,7 +8,6 @@ import 'package:lotti/blocs/sync/imap/imap_state.dart';
 import 'package:lotti/blocs/sync/imap/outbox_save_imap.dart';
 import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/main.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 class OutboxImapCubit extends Cubit<ImapState> {
   final String sharedSecretKey = 'sharedSecret';
@@ -49,13 +48,7 @@ class OutboxImapCubit extends Cubit<ImapState> {
       await transaction.finish();
 
       String? resDetails = res?.details;
-      _insightsDb.captureEvent(
-        SentryEvent(
-          message: SentryMessage(
-            resDetails ?? 'no result details',
-          ),
-        ),
-      );
+      _insightsDb.captureEvent(resDetails ?? 'no result details');
 
       if (resDetails != null && resDetails.contains('completed')) {
         return imapClient;

--- a/lotti/lib/blocs/sync/imap/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_cubit.dart
@@ -64,7 +64,7 @@ class OutboxImapCubit extends Cubit<ImapState> {
         return null;
       }
     } catch (exception, stackTrace) {
-      await Sentry.captureException(
+      await _insightsDb.captureException(
         exception,
         stackTrace: stackTrace,
       );

--- a/lotti/lib/blocs/sync/imap/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_cubit.dart
@@ -26,7 +26,7 @@ class OutboxImapCubit extends Cubit<ImapState> {
   }) async {
     ImapClient? imapClient;
     try {
-      final transaction = Sentry.startTransaction('saveImap()', 'task');
+      final transaction = _insightsDb.startTransaction('saveImap()', 'task');
       if (prevImapClient != null) {
         imapClient = prevImapClient;
       } else {

--- a/lotti/lib/blocs/sync/imap/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_cubit.dart
@@ -6,12 +6,15 @@ import 'package:enough_mail/enough_mail.dart';
 import 'package:lotti/blocs/sync/imap/imap_client.dart';
 import 'package:lotti/blocs/sync/imap/imap_state.dart';
 import 'package:lotti/blocs/sync/imap/outbox_save_imap.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class OutboxImapCubit extends Cubit<ImapState> {
   final String sharedSecretKey = 'sharedSecret';
   final String imapConfigKey = 'imapConfig';
   final String lastReadUidKey = 'lastReadUid';
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
 
   OutboxImapCubit() : super(ImapState.initial());
 
@@ -46,13 +49,13 @@ class OutboxImapCubit extends Cubit<ImapState> {
       await transaction.finish();
 
       String? resDetails = res?.details;
-      await Sentry.captureEvent(
-          SentryEvent(
-            message: SentryMessage(
-              resDetails ?? 'no result details',
-            ),
+      _insightsDb.captureEvent(
+        SentryEvent(
+          message: SentryMessage(
+            resDetails ?? 'no result details',
           ),
-          withScope: (Scope scope) => scope.level = SentryLevel.info);
+        ),
+      );
 
       if (resDetails != null && resDetails.contains('completed')) {
         return imapClient;

--- a/lotti/lib/blocs/sync/imap/outbox_save_imap.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_save_imap.dart
@@ -4,7 +4,6 @@ import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/main.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 Future<GenericImapResult> saveImapMessage(
   ImapClient imapClient,
@@ -15,7 +14,8 @@ Future<GenericImapResult> saveImapMessage(
   final InsightsDb _insightsDb = getIt<InsightsDb>();
 
   try {
-    final transaction = Sentry.startTransaction('saveImapMessage()', 'task');
+    final transaction =
+        _insightsDb.startTransaction('saveImapMessage()', 'task');
     Mailbox inbox = await imapClient.selectInbox();
     final builder = MessageBuilder.prepareMultipartAlternativeMessage();
     builder.from = [MailAddress('Sync', 'sender@domain.com')];

--- a/lotti/lib/blocs/sync/imap/outbox_save_imap.dart
+++ b/lotti/lib/blocs/sync/imap/outbox_save_imap.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/foundation.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 Future<GenericImapResult> saveImapMessage(
@@ -10,6 +12,8 @@ Future<GenericImapResult> saveImapMessage(
   String encryptedMessage, {
   File? file,
 }) async {
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+
   try {
     final transaction = Sentry.startTransaction('saveImapMessage()', 'task');
     Mailbox inbox = await imapClient.selectInbox();
@@ -35,7 +39,7 @@ Future<GenericImapResult> saveImapMessage(
     await transaction.finish();
     return res;
   } catch (exception, stackTrace) {
-    await Sentry.captureException(
+    await _insightsDb.captureException(
       exception,
       stackTrace: stackTrace,
     );

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -24,8 +24,6 @@ import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:mutex/mutex.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:sentry/sentry.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 class OutboxCubit extends Cubit<OutboxState> {
   final SyncConfigService _syncConfigService = getIt<SyncConfigService>();
@@ -89,9 +87,7 @@ class OutboxCubit extends Cubit<OutboxState> {
   }
 
   void reportConnectivity() async {
-    _insightsDb.captureEvent(SentryEvent(
-      message: SentryMessage(_connectivityResult.toString()),
-    ));
+    _insightsDb.captureEvent(_connectivityResult);
   }
 
   // Inserts a fault 25% of the time, where an exception would

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -182,7 +182,7 @@ class OutboxCubit extends Cubit<OutboxState> {
         stopPolling();
       }
     } catch (exception, stackTrace) {
-      await Sentry.captureException(exception, stackTrace: stackTrace);
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
       sendMutex.release();
       sendNext();
     }
@@ -247,7 +247,7 @@ class OutboxCubit extends Cubit<OutboxState> {
         await transaction.finish();
         startPolling();
       } catch (exception, stackTrace) {
-        await Sentry.captureException(exception, stackTrace: stackTrace);
+        await _insightsDb.captureException(exception, stackTrace: stackTrace);
       }
     }
 
@@ -275,7 +275,7 @@ class OutboxCubit extends Cubit<OutboxState> {
         await transaction.finish();
         startPolling();
       } catch (exception, stackTrace) {
-        await Sentry.captureException(exception, stackTrace: stackTrace);
+        await _insightsDb.captureException(exception, stackTrace: stackTrace);
       }
     }
   }

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -107,7 +107,7 @@ class OutboxCubit extends Cubit<OutboxState> {
   void sendNext({ImapClient? imapClient}) async {
     if (state is OutboxDisabled) return;
 
-    final transaction = Sentry.startTransaction('sendNext()', 'task');
+    final transaction = _insightsDb.startTransaction('sendNext()', 'task');
     try {
       _connectivityResult = await Connectivity().checkConnectivity();
       if (_connectivityResult == ConnectivityResult.none) {
@@ -204,7 +204,8 @@ class OutboxCubit extends Cubit<OutboxState> {
 
   Future<void> enqueueMessage(SyncMessage syncMessage) async {
     if (syncMessage is SyncJournalEntity) {
-      final transaction = Sentry.startTransaction('enqueueMessage()', 'task');
+      final transaction =
+          _insightsDb.startTransaction('enqueueMessage()', 'task');
       try {
         JournalEntity journalEntity = syncMessage.journalEntity;
         String jsonString = json.encode(syncMessage);
@@ -252,7 +253,8 @@ class OutboxCubit extends Cubit<OutboxState> {
     }
 
     if (syncMessage is SyncEntityDefinition) {
-      final transaction = Sentry.startTransaction('enqueueMessage()', 'task');
+      final transaction =
+          _insightsDb.startTransaction('enqueueMessage()', 'task');
       try {
         String jsonString = json.encode(syncMessage);
         final VectorClockService vectorClockService =

--- a/lotti/lib/database/insights_db.dart
+++ b/lotti/lib/database/insights_db.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:lotti/utils/file_utils.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'insights_db.g.dart';
+
+enum InsightLevel {
+  error,
+  warn,
+  info,
+  trace,
+}
+
+enum InsightType {
+  log,
+  exception,
+}
+
+@DriftDatabase(
+  include: {'insights_db.drift'},
+)
+class InsightsDb extends _$InsightsDb {
+  InsightsDb() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+
+  Future<int> logInsight(InsightsDbEntity insight) async {
+    return into(insights).insert(insight);
+  }
+
+  Future<void> captureEvent(
+    dynamic event, {
+    required String domain,
+    InsightLevel level = InsightLevel.info,
+    InsightType type = InsightType.log,
+  }) async {
+    logInsight(InsightsDbEntity(
+      id: uuid.v1(),
+      createdAt: DateTime.now().toIso8601String(),
+      domain: domain,
+      message: event.toString(),
+      level: level.name.toUpperCase(),
+      type: type.name.toUpperCase(),
+    ));
+  }
+
+  Stream<List<InsightsDbEntity>> watchInsights({
+    required List<String> types,
+    int limit = 1000,
+  }) {
+    return filteredInsights(types, limit).watch();
+  }
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, 'insights_db.sqlite'));
+    return NativeDatabase(file);
+  });
+}

--- a/lotti/lib/database/insights_db.dart
+++ b/lotti/lib/database/insights_db.dart
@@ -67,11 +67,19 @@ class InsightsDb extends _$InsightsDb {
     ));
   }
 
+  InsightsSpan startTransaction(String name, String operation) {
+    return InsightsSpan();
+  }
+
   Stream<List<Insight>> watchInsights({
     int limit = 1000,
   }) {
     return allInsights(limit).watch();
   }
+}
+
+class InsightsSpan {
+  Future<void> finish() async {}
 }
 
 LazyDatabase _openConnection() {

--- a/lotti/lib/database/insights_db.dart
+++ b/lotti/lib/database/insights_db.dart
@@ -49,6 +49,24 @@ class InsightsDb extends _$InsightsDb {
     ));
   }
 
+  Future<void> captureException(
+    dynamic exception, {
+    String domain = '',
+    dynamic stackTrace,
+    InsightLevel level = InsightLevel.error,
+    InsightType type = InsightType.exception,
+  }) async {
+    logInsight(Insight(
+      id: uuid.v1(),
+      createdAt: DateTime.now().toIso8601String(),
+      domain: domain,
+      message: exception.toString(),
+      stacktrace: stackTrace.toString(),
+      level: level.name.toUpperCase(),
+      type: type.name.toUpperCase(),
+    ));
+  }
+
   Stream<List<Insight>> watchInsights({
     int limit = 1000,
   }) {

--- a/lotti/lib/database/insights_db.dart
+++ b/lotti/lib/database/insights_db.dart
@@ -29,7 +29,7 @@ class InsightsDb extends _$InsightsDb {
   @override
   int get schemaVersion => 1;
 
-  Future<int> logInsight(InsightsDbEntity insight) async {
+  Future<int> logInsight(Insight insight) async {
     return into(insights).insert(insight);
   }
 
@@ -39,7 +39,7 @@ class InsightsDb extends _$InsightsDb {
     InsightLevel level = InsightLevel.info,
     InsightType type = InsightType.log,
   }) async {
-    logInsight(InsightsDbEntity(
+    logInsight(Insight(
       id: uuid.v1(),
       createdAt: DateTime.now().toIso8601String(),
       domain: domain,
@@ -49,11 +49,10 @@ class InsightsDb extends _$InsightsDb {
     ));
   }
 
-  Stream<List<InsightsDbEntity>> watchInsights({
-    required List<String> types,
+  Stream<List<Insight>> watchInsights({
     int limit = 1000,
   }) {
-    return filteredInsights(types, limit).watch();
+    return allInsights(limit).watch();
   }
 }
 

--- a/lotti/lib/database/insights_db.dart
+++ b/lotti/lib/database/insights_db.dart
@@ -35,7 +35,7 @@ class InsightsDb extends _$InsightsDb {
 
   Future<void> captureEvent(
     dynamic event, {
-    required String domain,
+    String domain = '',
     InsightLevel level = InsightLevel.info,
     InsightType type = InsightType.log,
   }) async {

--- a/lotti/lib/database/insights_db.drift
+++ b/lotti/lib/database/insights_db.drift
@@ -1,0 +1,26 @@
+CREATE TABLE insights (
+  id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  domain TEXT NOT NULL,
+  type TEXT NOT NULL,
+  level TEXT NOT NULL,
+  message TEXT NOT NULL,
+  stacktrace TEXT,
+  PRIMARY KEY (id)
+) as InsightsDbEntity;
+
+CREATE INDEX idx_insights_created_at
+ON insights (created_at);
+
+CREATE INDEX idx_insights_level
+ON insights (level);
+
+CREATE INDEX idx_insights_type
+ON insights (type);
+
+/* Queries ----------------------------------------------------- */
+filteredInsights:
+SELECT * FROM insights
+  WHERE type IN :types
+  ORDER BY created_at DESC
+  LIMIT :limit;

--- a/lotti/lib/database/insights_db.drift
+++ b/lotti/lib/database/insights_db.drift
@@ -7,7 +7,7 @@ CREATE TABLE insights (
   message TEXT NOT NULL,
   stacktrace TEXT,
   PRIMARY KEY (id)
-) as InsightsDbEntity;
+);
 
 CREATE INDEX idx_insights_created_at
 ON insights (created_at);
@@ -19,6 +19,11 @@ CREATE INDEX idx_insights_type
 ON insights (type);
 
 /* Queries ----------------------------------------------------- */
+allInsights:
+SELECT * FROM insights
+  ORDER BY created_at DESC
+  LIMIT :limit;
+
 filteredInsights:
 SELECT * FROM insights
   WHERE type IN :types

--- a/lotti/lib/main.dart
+++ b/lotti/lib/main.dart
@@ -18,12 +18,10 @@ import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/widgets/home.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'database/database.dart';
 import 'database/sync_db.dart';
 
-const enableSentry = false;
 final getIt = GetIt.instance;
 
 Future<void> main() async {
@@ -37,20 +35,7 @@ Future<void> main() async {
   getIt.registerSingleton<SyncConfigService>(SyncConfigService());
 
   initializeDateFormatting();
-
-  if (enableSentry) {
-    await SentryFlutter.init(
-      (options) {
-        options.dsn = dotenv.env['SENTRY_DSN'];
-        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-        // We recommend adjusting this value in production.
-        options.tracesSampleRate = 1.0;
-      },
-      appRunner: () => runApp(const LottiApp()),
-    );
-  } else {
-    runApp(const LottiApp());
-  }
+  runApp(const LottiApp());
 }
 
 class LottiApp extends StatelessWidget {

--- a/lotti/lib/main.dart
+++ b/lotti/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:lotti/blocs/sync/imap/inbox_cubit.dart';
 import 'package:lotti/blocs/sync/imap/outbox_cubit.dart';
 import 'package:lotti/blocs/sync/outbox_cubit.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
+import 'package:lotti/database/insights_db.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/widgets/home.dart';
@@ -31,6 +32,7 @@ Future<void> main() async {
 
   getIt.registerSingleton<JournalDb>(JournalDb());
   getIt.registerSingleton<SyncDatabase>(SyncDatabase());
+  getIt.registerSingleton<InsightsDb>(InsightsDb());
   getIt.registerSingleton<VectorClockService>(VectorClockService());
   getIt.registerSingleton<SyncConfigService>(SyncConfigService());
 

--- a/lotti/lib/sync/encryption.dart
+++ b/lotti/lib/sync/encryption.dart
@@ -4,11 +4,13 @@ import 'dart:io';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter/foundation.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/sync/encryption_messages.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 FutureOr<void> encryptFileIsolate(EncryptFileMessage msg) async {
-  final transaction = Sentry.startTransaction('encryptFile()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+  final transaction = _insightsDb.startTransaction('encryptFile()', 'task');
 
   if (!msg.inputFile.existsSync()) {
     debugPrint('File ${msg.inputFile} does not exist, aborting');
@@ -48,7 +50,8 @@ Future<void> encryptFile(
 }
 
 FutureOr<void> decryptFileIsolate(DecryptFileMessage msg) async {
-  final transaction = Sentry.startTransaction('decryptFile()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+  final transaction = _insightsDb.startTransaction('decryptFile()', 'task');
 
   if (!msg.inputFile.existsSync()) {
     debugPrint('File does not exist, aborting');
@@ -83,7 +86,10 @@ Future<void> decryptFile(
 }
 
 Future<String> encryptStringIsolate(EncryptStringMessage msg) async {
-  final transaction = Sentry.startTransaction('encryptStringIsolate()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+  final transaction =
+      _insightsDb.startTransaction('encryptStringIsolate()', 'task');
+
   final List<int> message = utf8.encode(msg.plaintext);
   final algorithm = AesGcm.with256bits();
   final secretKey =
@@ -113,7 +119,9 @@ Future<String> encryptString({
 }
 
 FutureOr<String> decryptStringIsolate(DecryptStringMessage msg) async {
-  final transaction = Sentry.startTransaction('decryptStringIsolate()', 'task');
+  final InsightsDb _insightsDb = getIt<InsightsDb>();
+  final transaction =
+      _insightsDb.startTransaction('decryptStringIsolate()', 'task');
 
   final algorithm = AesGcm.with256bits();
   final List<int> bytes = base64.decode(msg.encrypted);

--- a/lotti/lib/sync/encryption.dart
+++ b/lotti/lib/sync/encryption.dart
@@ -4,14 +4,9 @@ import 'dart:io';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter/foundation.dart';
-import 'package:lotti/database/insights_db.dart';
-import 'package:lotti/main.dart';
 import 'package:lotti/sync/encryption_messages.dart';
 
 FutureOr<void> encryptFileIsolate(EncryptFileMessage msg) async {
-  final InsightsDb _insightsDb = getIt<InsightsDb>();
-  final transaction = _insightsDb.startTransaction('encryptFile()', 'task');
-
   if (!msg.inputFile.existsSync()) {
     debugPrint('File ${msg.inputFile} does not exist, aborting');
     throw Exception("File not found");
@@ -30,7 +25,6 @@ FutureOr<void> encryptFileIsolate(EncryptFileMessage msg) async {
   );
 
   await msg.encryptedFile.writeAsBytes(secretBox.concatenation());
-  await transaction.finish();
 }
 
 Future<void> encryptFile(
@@ -50,9 +44,6 @@ Future<void> encryptFile(
 }
 
 FutureOr<void> decryptFileIsolate(DecryptFileMessage msg) async {
-  final InsightsDb _insightsDb = getIt<InsightsDb>();
-  final transaction = _insightsDb.startTransaction('decryptFile()', 'task');
-
   if (!msg.inputFile.existsSync()) {
     debugPrint('File does not exist, aborting');
     throw Exception("File not found");
@@ -71,7 +62,6 @@ FutureOr<void> decryptFileIsolate(DecryptFileMessage msg) async {
   );
 
   await msg.decryptedFile.writeAsBytes(decryptedBytes);
-  await transaction.finish();
 }
 
 Future<void> decryptFile(
@@ -86,10 +76,6 @@ Future<void> decryptFile(
 }
 
 Future<String> encryptStringIsolate(EncryptStringMessage msg) async {
-  final InsightsDb _insightsDb = getIt<InsightsDb>();
-  final transaction =
-      _insightsDb.startTransaction('encryptStringIsolate()', 'task');
-
   final List<int> message = utf8.encode(msg.plaintext);
   final algorithm = AesGcm.with256bits();
   final secretKey =
@@ -101,7 +87,6 @@ Future<String> encryptStringIsolate(EncryptStringMessage msg) async {
     secretKey: secretKey,
     nonce: nonce,
   );
-  transaction.finish();
   return base64.encode(secretBox.concatenation());
 }
 
@@ -119,10 +104,6 @@ Future<String> encryptString({
 }
 
 FutureOr<String> decryptStringIsolate(DecryptStringMessage msg) async {
-  final InsightsDb _insightsDb = getIt<InsightsDb>();
-  final transaction =
-      _insightsDb.startTransaction('decryptStringIsolate()', 'task');
-
   final algorithm = AesGcm.with256bits();
   final List<int> bytes = base64.decode(msg.encrypted);
   final deserializedSecretBox =
@@ -136,7 +117,6 @@ FutureOr<String> decryptStringIsolate(DecryptStringMessage msg) async {
   );
 
   String decrypted = utf8.decode(decryptedBytes);
-  transaction.finish();
   return decrypted;
 }
 

--- a/lotti/lib/widgets/pages/settings/insights_page.dart
+++ b/lotti/lib/widgets/pages/settings/insights_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lotti/blocs/sync/outbox_cubit.dart';
+import 'package:lotti/blocs/sync/outbox_state.dart';
+import 'package:lotti/database/insights_db.dart';
+import 'package:lotti/main.dart';
+import 'package:lotti/theme.dart';
+
+class InsightsPage extends StatefulWidget {
+  const InsightsPage({Key? key}) : super(key: key);
+
+  @override
+  State<InsightsPage> createState() => _InsightsPageState();
+}
+
+class _InsightsPageState extends State<InsightsPage> {
+  final InsightsDb _db = getIt<InsightsDb>();
+  late Stream<List<Insight>> stream = _db.watchInsights();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<OutboxCubit, OutboxState>(
+      builder: (context, OutboxState state) {
+        return StreamBuilder<List<Insight>>(
+          stream: stream,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<List<Insight>> snapshot,
+          ) {
+            List<Insight> insights = snapshot.data ?? [];
+
+            return Scaffold(
+              appBar: AppBar(
+                backgroundColor: AppColors.headerBgColor,
+                foregroundColor: AppColors.appBarFgColor,
+                title: const Text('Logging'),
+              ),
+              backgroundColor: AppColors.bodyBgColor,
+              body: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(8.0),
+                children: List.generate(
+                  insights.length,
+                  (int index) {
+                    return InsightCard(
+                      insight: insights.elementAt(index),
+                      index: index,
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class InsightCard extends StatelessWidget {
+  final Insight insight;
+  final int index;
+
+  const InsightCard({
+    Key? key,
+    required this.insight,
+    required this.index,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: Text(
+        '${insight.createdAt.substring(0, 23)}: ${insight.message}',
+        style: TextStyle(
+          color: AppColors.entryTextColor,
+          fontFamily: 'ShareTechMono',
+          fontSize: 16.0,
+        ),
+      ),
+    );
+  }
+}

--- a/lotti/lib/widgets/pages/settings/settings_page.dart
+++ b/lotti/lib/widgets/pages/settings/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:lotti/blocs/journal/persistence_state.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/misc/app_bar_version.dart';
 import 'package:lotti/widgets/pages/settings/conflicts.dart';
+import 'package:lotti/widgets/pages/settings/insights_page.dart';
 import 'package:lotti/widgets/pages/settings/measurables.dart';
 import 'package:lotti/widgets/pages/settings/outbox_monitor.dart';
 import 'package:lotti/widgets/pages/settings/sync_settings.dart';
@@ -82,6 +83,19 @@ class _SettingsPageState extends State<SettingsPage> {
                               MaterialPageRoute(
                                 builder: (BuildContext context) {
                                   return const OutboxMonitorPage();
+                                },
+                              ),
+                            );
+                          },
+                        ),
+                        SettingsCard(
+                          iconData: MdiIcons.information,
+                          title: 'Logs',
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (BuildContext context) {
+                                  return const InsightsPage();
                                 },
                               ),
                             );

--- a/lotti/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/lotti/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import location
 import package_info_plus_macos
 import path_provider_macos
 import photo_manager
-import sentry_flutter
 import sqflite
 import sqlite3_flutter_libs
 import url_launcher_macos
@@ -31,7 +30,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ImageScannerPlugin.register(with: registry.registrar(forPlugin: "ImageScannerPlugin"))
-  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -526,13 +526,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
-  file_utils:
-    dependency: transitive
-    description:
-      name: file_utils
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -821,13 +814,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
-  globbing:
-    dependency: transitive
-    description:
-      name: globbing
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -926,13 +912,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.1"
-  injector:
-    dependency: transitive
-    description:
-      name: injector
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1418,27 +1397,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.3"
-  sentry:
-    dependency: transitive
-    description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.2.2"
-  sentry_dart_plugin:
-    dependency: "direct dev"
-    description:
-      name: sentry_dart_plugin
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0-beta.1"
-  sentry_flutter:
-    dependency: "direct main"
-    description:
-      name: sentry_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.2.2"
   shelf:
     dependency: transitive
     description:
@@ -1619,13 +1577,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
-  system_info:
-    dependency: transitive
-    description:
-      name: system_info
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
   term_glyph:
     dependency: transitive
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.25+227
+version: 0.3.25+228
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -66,7 +66,6 @@ dependencies:
   permission_handler: ^8.1.6
   qr_code_scanner: ^0.6.1
   qr_flutter: ^4.0.0
-  sentry_flutter: ^6.2.1
   sqflite: ^2.0.1
   sqlite3_flutter_libs: ^0.5.2
   syncfusion_flutter_datepicker: ^19.3.57
@@ -86,7 +85,6 @@ dev_dependencies:
   freezed: ^1.1.0
   glados: ^1.1.1
   json_serializable: ^6.0.0
-  sentry_dart_plugin: ^1.0.0-beta.1
 
 analyzer:
   plugins:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.25+226
+version: 0.3.25+227
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.24+224
+version: 0.3.25+225
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.25+225
+version: 0.3.25+226
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes Sentry and replaces it with an insights database on the device where events and exceptions can be logged, and later analyzed if necessary. The interface will need work, feels a bit cumbersome. Includes a very basic logging view widget, which updates automatically when new events are recorded. Will require filtering to become useful. Would be even more useful with sync for such log/insight event, so that events from mobile can be properly seen on desktop, potentially with a detail page that allows drilling into one or more attached data samples.