### PR TITLE
Limit width to half the screen width in journal card

### DIFF
--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -225,10 +225,13 @@ class JournalImageCard extends StatelessWidget {
           child: GFListTile(
             margin: EdgeInsets.zero,
             padding: const EdgeInsets.only(right: 16),
-            avatar: EntryImageWidget(
-              journalImage: item,
-              height: 160,
-              fit: BoxFit.cover,
+            avatar: LimitedBox(
+              maxWidth: MediaQuery.of(context).size.width / 2,
+              child: EntryImageWidget(
+                journalImage: item,
+                height: 160,
+                fit: BoxFit.cover,
+              ),
             ),
             title: JournalCardTitle(item: item),
             icon: Column(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.29+238
+version: 0.3.30+239
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR limits the maximum image width in the journal image card, for example for panoramas.