### PR TITLE
Upgrade flutter quill

### DIFF
--- a/lotti/lib/widgets/journal/text_viewer_widget.dart
+++ b/lotti/lib/widgets/journal/text_viewer_widget.dart
@@ -24,7 +24,7 @@ class TextViewerWidget extends StatelessWidget {
           controller: _controller,
           readOnly: true,
           scrollController: ScrollController(),
-          scrollable: false,
+          scrollable: true,
           focusNode: FocusNode(canRequestFocus: false),
           autoFocus: false,
           expands: false,

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -368,9 +368,11 @@ packages:
   delta_markdown:
     dependency: "direct main"
     description:
-      name: delta_markdown
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: "1a6da0a"
+      resolved-ref: "1a6da0a8e913a8b24c54a7368955d11799e2b318"
+      url: "https://github.com/matthiasn/delta_markdown"
+    source: git
     version: "0.3.0"
   device_info_plus:
     dependency: "direct main"
@@ -714,7 +716,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.2"
+    version: "3.2.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.32+241
+version: 0.3.32+242
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -22,6 +22,12 @@ dependencies:
       url: https://github.com/matthiasn/enough_mail
       ref: 0c261a7
 
+  # TODO: replace when https://github.com/friebetill/delta_markdown/issues/4 resolved
+  delta_markdown:
+    git:
+      url: https://github.com/matthiasn/delta_markdown
+      ref: 1a6da0a
+
   audio_video_progress_bar: ^0.10.0
   bloc: ^8.0.1
   bloc_test: ^9.0.1
@@ -32,7 +38,7 @@ dependencies:
   cryptography: ^2.0.2
   cupertino_icons: ^1.0.2
   dart_geohash: ^2.0.1
-  delta_markdown: ^0.3.0
+  # delta_markdown: ^0.3.0
   device_info_plus: ^3.1.0
   drift: ^1.1.0
   # enough_mail: ^1.3.6
@@ -48,7 +54,7 @@ dependencies:
   flutter_local_notifications: ^9.2.0
   flutter_map: ^0.14.0
   flutter_native_timezone: ^2.0.0
-  flutter_quill: ^2.5.2
+  flutter_quill: ^3.2.0
   flutter_secure_storage: ^5.0.0
   flutter_sound: ^8.3.12
   form_builder_validators: ^7.2.0


### PR DESCRIPTION
This PR upgrades `flutter_quill` to the latest version. For now, this requires using a fork of `delta_markdown`, which can be changed back to a published version when [this PR](https://github.com/friebetill/delta_markdown/pull/5) is merged.