### PR TITLE
Update delta_markdown

### DIFF
--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.32+242
+version: 0.3.32+243
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -22,12 +22,6 @@ dependencies:
       url: https://github.com/matthiasn/enough_mail
       ref: 0c261a7
 
-  # TODO: replace when https://github.com/friebetill/delta_markdown/issues/4 resolved
-  delta_markdown:
-    git:
-      url: https://github.com/matthiasn/delta_markdown
-      ref: 1a6da0a
-
   audio_video_progress_bar: ^0.10.0
   bloc: ^8.0.1
   bloc_test: ^9.0.1
@@ -38,7 +32,7 @@ dependencies:
   cryptography: ^2.0.2
   cupertino_icons: ^1.0.2
   dart_geohash: ^2.0.1
-  # delta_markdown: ^0.3.0
+  delta_markdown: ^0.4.0
   device_info_plus: ^3.1.0
   drift: ^1.1.0
   # enough_mail: ^1.3.6


### PR DESCRIPTION
This PR updates `delta_markdown` after the merge and publication of the [update-delta-markdown PR](https://github.com/friebetill/delta_markdown/pull/5).