### PR TITLE
Improve badges notifications

### DIFF
--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -157,6 +157,10 @@ class JournalDb extends _$JournalDb {
     return res.first;
   }
 
+  Stream<int> watchCountImportFlagEntries() {
+    return countImportFlagEntries().watch().map((event) => event.first);
+  }
+
   Stream<List<MeasurableDataType>> watchMeasurableDataTypes() {
     return activeMeasurableTypes().watch().map(measurableDataTypeStreamMapper);
   }

--- a/lotti/lib/services/notification_service.dart
+++ b/lotti/lib/services/notification_service.dart
@@ -58,7 +58,7 @@ class NotificationService {
       body,
       NotificationDetails(
         iOS: IOSNotificationDetails(
-          presentAlert: true,
+          presentAlert: false,
           presentBadge: true,
           badgeNumber: counter,
         ),

--- a/lotti/lib/widgets/bottom_nav/flagged_badge_icon.dart
+++ b/lotti/lib/widgets/bottom_nav/flagged_badge_icon.dart
@@ -1,0 +1,33 @@
+import 'package:badges/badges.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+
+class FlaggedBadgeIcon extends StatelessWidget {
+  final JournalDb _db = getIt<JournalDb>();
+
+  FlaggedBadgeIcon({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<int>(
+      stream: _db.watchCountImportFlagEntries(),
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<int> snapshot,
+      ) {
+        int? count = snapshot.data;
+        return Badge(
+          badgeContent: Text(snapshot.data.toString()),
+          showBadge: count != null && count != 0,
+          toAnimate: false,
+          elevation: 3,
+          child: const Icon(MdiIcons.flag),
+        );
+      },
+    );
+  }
+}

--- a/lotti/lib/widgets/home.dart
+++ b/lotti/lib/widgets/home.dart
@@ -6,7 +6,8 @@ import 'package:lotti/widgets/pages/audio.dart';
 import 'package:lotti/widgets/pages/flagged_entries_page.dart';
 import 'package:lotti/widgets/pages/journal_page.dart';
 import 'package:lotti/widgets/pages/settings/settings_page.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+
+import 'bottom_nav/flagged_badge_icon.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -51,24 +52,24 @@ class _HomePageState extends State<HomePage> {
         backgroundColor: AppColors.headerBgColor,
         bottomNavigationBar: BottomNavigationBar(
           type: BottomNavigationBarType.fixed,
-          items: const <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
+          items: <BottomNavigationBarItem>[
+            const BottomNavigationBarItem(
               icon: Icon(Icons.home),
               label: 'Journal',
             ),
             BottomNavigationBarItem(
-              icon: Icon(MdiIcons.flag),
+              icon: FlaggedBadgeIcon(),
               label: 'Flagged',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.add_box),
               label: 'Add',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.mic),
               label: 'Audio',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.settings),
               label: 'Settings',
             ),

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.0"
+  badges:
+    dependency: "direct main"
+    description:
+      name: badges
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   basic_utils:
     dependency: transitive
     description:
@@ -368,12 +375,10 @@ packages:
   delta_markdown:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "1a6da0a"
-      resolved-ref: "1a6da0a8e913a8b24c54a7368955d11799e2b318"
-      url: "https://github.com/matthiasn/delta_markdown"
-    source: git
-    version: "0.3.0"
+      name: delta_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
   device_info_plus:
     dependency: "direct main"
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -81,6 +81,7 @@ dependencies:
   wechat_assets_picker: ^6.3.0
   yaml: ^3.1.0
   flutter_app_badger: ^1.3.0
+  badges: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.32+243
+version: 0.3.33+244
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR improves badges and notifications for flagged entries that need annotation. Removes the notification on mobile, that's pointless as it won't receive anything in the background anyway. Then adds a badge in the bottom nav bar with the number of flagged items.