### PR TITLE
Remove tooltips in bottom nav bar - fixes flickering badge

### DIFF
--- a/lotti/lib/widgets/home.dart
+++ b/lotti/lib/widgets/home.dart
@@ -56,22 +56,27 @@ class _HomePageState extends State<HomePage> {
             const BottomNavigationBarItem(
               icon: Icon(Icons.home),
               label: 'Journal',
+              tooltip: '',
             ),
             BottomNavigationBarItem(
               icon: FlaggedBadgeIcon(),
               label: 'Flagged',
+              tooltip: '',
             ),
             const BottomNavigationBarItem(
               icon: Icon(Icons.add_box),
               label: 'Add',
+              tooltip: '',
             ),
             const BottomNavigationBarItem(
               icon: Icon(Icons.mic),
               label: 'Audio',
+              tooltip: '',
             ),
             const BottomNavigationBarItem(
               icon: Icon(Icons.settings),
               label: 'Settings',
+              tooltip: '',
             ),
           ],
           selectedItemColor: Colors.amber[800],

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.33+244
+version: 0.3.34+245
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes the useless tooltips on desktop that show exactly the same as the text under each icon already shows. Incidentally, this also fixes the flicker on the badge when the mouse pointer enters or leaves the desktop app.