### PR TITLE
Pin version of flutter_health_fit

### DIFF
--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -614,7 +614,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
+      ref: "459aaa3"
       resolved-ref: "459aaa32e8bd29288b093a22905a185d04b0c1e6"
       url: "https://github.com/metaflowltd/flutter_health_fit.git"
     source: git
@@ -1034,7 +1034,7 @@ packages:
     source: hosted
     version: "1.8.1"
   lints:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: lints
       url: "https://pub.dartlang.org"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.35+246
+version: 0.3.36+247
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -11,7 +11,9 @@ dependencies:
     sdk: flutter
 
   flutter_health_fit:
-    git: https://github.com/metaflowltd/flutter_health_fit.git
+    git:
+      url: https://github.com/metaflowltd/flutter_health_fit.git
+      ref: 459aaa3
 
   # research_package: ^0.6.7
   research_package:


### PR DESCRIPTION
This PR pins the version of `flutter_health_fit` to make the build more predictable. This is a workaround until the library is published, also see [this issue](https://github.com/metaflowltd/flutter_health_fit/issues/40).