### PR TITLE
Create new audio recorder for every recording

### DIFF
--- a/lotti/lib/blocs/audio/recorder_cubit.dart
+++ b/lotti/lib/blocs/audio/recorder_cubit.dart
@@ -25,7 +25,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
   late final PersistenceCubit _persistenceCubit;
   final InsightsDb _insightsDb = getIt<InsightsDb>();
 
-  final FlutterSoundRecorder? _myRecorder = FlutterSoundRecorder();
+  FlutterSoundRecorder? _myRecorder;
   AudioNote? _audioNote;
   final DeviceLocation _deviceLocation = DeviceLocation();
 
@@ -43,7 +43,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
               'Microphone permission not granted');
         }
       }
-
+      _myRecorder = FlutterSoundRecorder();
       await _myRecorder?.openAudioSession();
       emit(state.copyWith(status: AudioRecorderStatus.initialized));
       _myRecorder?.setSubscriptionDuration(const Duration(milliseconds: 500));

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.38+250
+version: 0.3.39+251
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes the lifecycle of the audio recorder to create a new instance of `FlutterSoundRecorder` on ever recording. This should improve stability. Before, the `FlutterSoundRecorder` would sometimes become unresponsive after resuming from the background.