### PR TITLE
Restart IMAP inbox on network reconnect

### DIFF
--- a/lotti/lib/blocs/sync/imap/inbox_cubit.dart
+++ b/lotti/lib/blocs/sync/imap/inbox_cubit.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
@@ -58,6 +59,19 @@ class InboxImapCubit extends Cubit<ImapState> {
         }
       });
     }
+
+    Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+      _insightsDb
+          .captureEvent('INBOX: Connectivity onConnectivityChanged $result');
+
+      if (result == ConnectivityResult.none) {
+        _stopPeriodicFetching();
+      } else {
+        _startPeriodicFetching();
+        _observeInbox();
+      }
+    });
+
     _startPeriodicFetching();
     _observeInbox();
   }

--- a/lotti/lib/blocs/sync/outbox_cubit.dart
+++ b/lotti/lib/blocs/sync/outbox_cubit.dart
@@ -47,6 +47,9 @@ class OutboxCubit extends Cubit<OutboxState> {
     Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
       _connectivityResult = result;
       debugPrint('Connectivity onConnectivityChanged $result');
+      _insightsDb
+          .captureEvent('OUTBOX: Connectivity onConnectivityChanged $result');
+
       if (result == ConnectivityResult.none) {
         stopPolling();
       } else {

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.39+251
+version: 0.3.40+252
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This commit adds restarting the IMAP inbox listener on detected network connectivity changes when the status is anything other than `ConnectivityResult.none`.