### PR TITLE
Remove apt-get update

### DIFF
--- a/.github/workflows/flutter-linux-build.yml
+++ b/.github/workflows/flutter-linux-build.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
-      - name: Update apt
-        run: sudo apt-get update && sudo apt-get upgrade
       - name: Install libraries
         run: sudo apt-get install libgtk-3-dev cmake cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libjsoncpp1 libsecret-1-0 sqlite3 libsqlite3-dev
       - name: Enable Linux Desktop


### PR DESCRIPTION
This PR reduces the build time for the Flutter Linux build by about 2 minutes.