### PR TITLE
Add private status in data model

### DIFF
--- a/lotti/lib/classes/journal_entities.dart
+++ b/lotti/lib/classes/journal_entities.dart
@@ -32,6 +32,7 @@ class Metadata with _$Metadata {
     DateTime? deletedAt,
     EntryFlag? flag,
     bool? starred,
+    bool? private,
   }) = _Metadata;
 
   factory Metadata.fromJson(Map<String, dynamic> json) =>

--- a/lotti/lib/classes/measurables.dart
+++ b/lotti/lib/classes/measurables.dart
@@ -19,6 +19,7 @@ class EntityDefinition with _$EntityDefinition {
     required int version,
     required VectorClock? vectorClock,
     DateTime? deletedAt,
+    bool? private,
     AggregationType? aggregationType,
   }) = MeasurableDataType;
 

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -34,6 +34,7 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
     dateFrom: entity.meta.dateFrom,
     deleted: entity.meta.deletedAt != null,
     starred: entity.meta.starred ?? false,
+    private: entity.meta.private ?? false,
     flag: entity.meta.flag?.index ?? 0,
     dateTo: entity.meta.dateTo,
     type: entity.runtimeType.toString().replaceFirst(r'_$', ''),
@@ -78,6 +79,7 @@ MeasurableDbEntity measurableDbEntity(EntityDefinition dataType) {
     serialized: jsonEncode(dataType),
     version: dataType.version,
     status: 0,
+    private: dataType.private ?? false,
     deleted: dataType.deletedAt != null,
   );
 }

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -7,6 +7,7 @@ CREATE TABLE journal (
   date_to DATETIME NOT NULL,
   deleted BOOLEAN NOT NULL DEFAULT FALSE,
   starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
   flag INTEGER NOT NULL DEFAULT 0,
   type TEXT NOT NULL,
   subtype TEXT,
@@ -37,6 +38,9 @@ ON journal (deleted);
 
 CREATE INDEX idx_journal_starred
 ON journal (starred);
+
+CREATE INDEX idx_journal_private
+ON journal (private);
 
 CREATE INDEX idx_journal_flag
 ON journal (flag);
@@ -71,6 +75,7 @@ CREATE TABLE measurable_types (
   created_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL,
   deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
   serialized TEXT NOT NULL,
   version INTEGER NOT NULL DEFAULT 0,
   status INTEGER NOT NULL,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.42+254
+version: 0.3.43+255
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a private flag for journal entries and measurement definitions which will make it easier to demonstrate the app while neither having to create (dull) test data nor having to reveal what is private. Setting the status and filtering will come in a subsequent PR.