### PR TITLE
Starred and private filter controls

### DIFF
--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -383,7 +383,7 @@ class PersistenceCubit extends Cubit<PersistenceState> {
     required DateTime dateTo,
   }) async {
     final transaction =
-        _insightsDb.startTransaction('updateJournalEntity()', 'task');
+        _insightsDb.startTransaction('updateJournalEntityDate()', 'task');
     try {
       DateTime now = DateTime.now();
       VectorClock vc = await _vectorClockService.getNextVectorClock(
@@ -394,6 +394,35 @@ class PersistenceCubit extends Cubit<PersistenceState> {
         vectorClock: vc,
         dateFrom: dateFrom,
         dateTo: dateTo,
+      );
+
+      JournalEntity newJournalEntity = journalEntity.copyWith(
+        meta: newMeta,
+      );
+
+      await updateDbEntity(newJournalEntity, enqueueSync: true);
+    } catch (exception, stackTrace) {
+      await _insightsDb.captureException(exception, stackTrace: stackTrace);
+    }
+
+    await transaction.finish();
+    return true;
+  }
+
+  Future<bool> updateJournalEntity(
+    JournalEntity journalEntity,
+    Metadata metadata,
+  ) async {
+    final transaction =
+        _insightsDb.startTransaction('updateJournalEntity()', 'task');
+    try {
+      DateTime now = DateTime.now();
+      VectorClock vc = await _vectorClockService.getNextVectorClock(
+          previous: metadata.vectorClock);
+
+      Metadata newMeta = metadata.copyWith(
+        updatedAt: now,
+        vectorClock: vc,
       );
 
       JournalEntity newJournalEntity = journalEntity.copyWith(

--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -310,13 +310,20 @@ class PersistenceCubit extends Cubit<PersistenceState> {
   }
 
   Future<bool> updateJournalEntityText(
-    JournalEntity journalEntity,
+    String journalEntityId,
     EntryText entryText,
   ) async {
     final transaction =
         _insightsDb.startTransaction('updateJournalEntity()', 'task');
     try {
       DateTime now = DateTime.now();
+      JournalEntity? journalEntity =
+          await _journalDb.journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
       VectorClock vc = await _vectorClockService.getNextVectorClock(
           previous: journalEntity.meta.vectorClock);
 

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -137,9 +137,12 @@ class JournalDb extends _$JournalDb {
 
   Stream<List<JournalEntity>> watchJournalEntities({
     required List<String> types,
+    required List<bool> starredStatuses,
     int limit = 1000,
   }) {
-    return filteredJournal(types, limit).watch().map(entityStreamMapper);
+    return filteredJournal(types, starredStatuses, limit)
+        .watch()
+        .map(entityStreamMapper);
   }
 
   Stream<List<JournalEntity>> watchFlaggedImport({

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -138,9 +138,10 @@ class JournalDb extends _$JournalDb {
   Stream<List<JournalEntity>> watchJournalEntities({
     required List<String> types,
     required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
     int limit = 1000,
   }) {
-    return filteredJournal(types, starredStatuses, limit)
+    return filteredJournal(types, starredStatuses, privateStatuses, limit)
         .watch()
         .map(entityStreamMapper);
   }

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -85,7 +85,9 @@ CREATE TABLE measurable_types (
 /* Queries ----------------------------------------------------- */
 filteredJournal:
 SELECT * FROM journal
-  WHERE type IN :types AND deleted = false
+  WHERE type IN :types
+  AND deleted = false
+  AND starred IN :starredStatuses
   ORDER BY date_from DESC
   LIMIT :limit;
 

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -88,6 +88,7 @@ SELECT * FROM journal
   WHERE type IN :types
   AND deleted = false
   AND starred IN :starredStatuses
+  AND private IN :privateStatuses
   ORDER BY date_from DESC
   LIMIT :limit;
 

--- a/lotti/lib/theme.dart
+++ b/lotti/lib/theme.dart
@@ -6,6 +6,7 @@ class AppColors {
   static Color entryBgColor = const Color.fromRGBO(155, 200, 245, 1);
   static Color entryTextColor = const Color.fromRGBO(158, 158, 158, 1);
   static Color editorTextColor = const Color.fromRGBO(51, 51, 51, 1);
+  static Color starredGold = const Color.fromRGBO(255, 215, 0, 1);
   static Color editorBgColor = Colors.white;
 
   static Color headerBgColor = const Color.fromRGBO(68, 68, 85, 1);

--- a/lotti/lib/theme.dart
+++ b/lotti/lib/theme.dart
@@ -23,6 +23,7 @@ class AppColors {
   static Color audioMeterTooHotBar = Colors.orange;
   static Color audioMeterPeakedBar = Colors.red;
   static Color error = Colors.red;
+  static Color private = Colors.red;
   static Color audioMeterBarBackground =
       TinyColor(headerBgColor).lighten(40).color;
   static Color inactiveAudioControl = const Color.fromRGBO(155, 155, 177, 1);

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -1,11 +1,14 @@
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
@@ -34,6 +37,7 @@ class EntryDetailWidget extends StatefulWidget {
 
 class _EntryDetailWidgetState extends State<EntryDetailWidget> {
   final FocusNode _focusNode = FocusNode();
+  bool showDetails = false;
 
   Directory? docDir;
   bool mapVisible = false;
@@ -99,18 +103,23 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
               ),
             ),
             IconButton(
-              icon: const Icon(MdiIcons.trashCanOutline),
+              icon: Icon(showDetails
+                  ? MdiIcons.chevronDoubleUp
+                  : MdiIcons.chevronDoubleDown),
               iconSize: 24,
-              tooltip: 'Delete',
+              tooltip: 'Details',
               color: AppColors.appBarFgColor,
               onPressed: () {
-                context
-                    .read<PersistenceCubit>()
-                    .deleteJournalEntity(widget.item);
-                Navigator.pop(context);
+                setState(() {
+                  showDetails = !showDetails;
+                });
               },
             ),
           ],
+        ),
+        Visibility(
+          visible: showDetails,
+          child: EntryInfoRow(entityId: widget.item.meta.id),
         ),
         Visibility(
           visible: mapVisible,
@@ -230,6 +239,103 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           orElse: () => Container(),
         ),
       ],
+    );
+  }
+}
+
+class EntryInfoRow extends StatelessWidget {
+  final String entityId;
+  final JournalDb db = getIt<JournalDb>();
+
+  late final Stream<JournalEntity?> stream = db.watchEntityById(entityId);
+
+  EntryInfoRow({
+    Key? key,
+    required this.entityId,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<JournalEntity?>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<JournalEntity?> snapshot,
+        ) {
+          JournalEntity? liveEntity = snapshot.data;
+          if (liveEntity == null) {
+            return const SizedBox.shrink();
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SwitchRow(
+                label: 'Starred:',
+                onChanged: (bool value) {
+                  Metadata newMeta = liveEntity.meta.copyWith(
+                    starred: value,
+                  );
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntity(liveEntity, newMeta);
+                },
+                value: liveEntity.meta.starred ?? false,
+              ),
+              SwitchRow(
+                label: 'Private:',
+                onChanged: (bool value) {
+                  Metadata newMeta = liveEntity.meta.copyWith(
+                    private: value,
+                  );
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntity(liveEntity, newMeta);
+                },
+                value: liveEntity.meta.private ?? false,
+              ),
+              SwitchRow(
+                label: 'Deleted:',
+                onChanged: (bool value) {
+                  if (value) {
+                    context
+                        .read<PersistenceCubit>()
+                        .deleteJournalEntity(liveEntity);
+                    Navigator.pop(context);
+                  }
+                },
+                value: liveEntity.meta.deletedAt != null,
+              ),
+            ],
+          );
+        });
+  }
+}
+
+class SwitchRow extends StatelessWidget {
+  const SwitchRow({
+    Key? key,
+    required this.label,
+    required this.onChanged,
+    required this.value,
+  }) : super(key: key);
+
+  final String label;
+  final void Function(bool)? onChanged;
+  final bool value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(label, style: textStyle),
+          CupertinoSwitch(value: value, onChanged: onChanged),
+        ],
+      ),
     );
   }
 }

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -137,7 +137,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
               context
                   .read<PersistenceCubit>()
-                  .updateJournalEntityText(widget.item, entryText);
+                  .updateJournalEntityText(widget.item.meta.id, entryText);
             }
 
             return Column(
@@ -161,7 +161,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
               context
                   .read<PersistenceCubit>()
-                  .updateJournalEntityText(widget.item, entryText);
+                  .updateJournalEntityText(widget.item.meta.id, entryText);
             }
 
             return Column(
@@ -191,7 +191,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
             void saveText() {
               context.read<PersistenceCubit>().updateJournalEntityText(
-                  widget.item, entryTextFromController(_controller));
+                  widget.item.meta.id, entryTextFromController(_controller));
             }
 
             return EditorWidget(
@@ -207,7 +207,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
             void saveText() {
               context.read<PersistenceCubit>().updateJournalEntityText(
-                  widget.item, entryTextFromController(_controller));
+                  widget.item.meta.id, entryTextFromController(_controller));
             }
 
             return EditorWidget(

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -13,6 +13,16 @@ import 'package:lotti/widgets/journal/text_viewer_widget.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
+bool fromNullableBool(bool? value) {
+  if (value != null) {
+    return value;
+  } else {
+    return false;
+  }
+}
+
+const double iconSize = 18.0;
+
 class JournalCardTitle extends StatelessWidget {
   final JournalEntity item;
   const JournalCardTitle({Key? key, required this.item}) : super(key: key);
@@ -25,14 +35,39 @@ class JournalCardTitle extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            df.format(item.meta.dateFrom),
-            style: TextStyle(
-              color: AppColors.entryTextColor,
-              fontSize: 11,
-              fontWeight: FontWeight.w500,
-              fontFamily: 'Oswald',
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                df.format(item.meta.dateFrom),
+                style: TextStyle(
+                  color: AppColors.entryTextColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  fontFamily: 'Oswald',
+                ),
+              ),
+              Expanded(child: Container()),
+              Visibility(
+                visible: fromNullableBool(item.meta.private),
+                child: Icon(
+                  MdiIcons.security,
+                  color: AppColors.error,
+                  size: iconSize,
+                ),
+              ),
+              Visibility(
+                visible: fromNullableBool(item.meta.starred),
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 4.0),
+                  child: Icon(
+                    MdiIcons.star,
+                    color: AppColors.starredGold,
+                    size: iconSize,
+                  ),
+                ),
+              ),
+            ],
           ),
           item.maybeMap(
             quantitative: (QuantitativeEntry qe) => qe.data.maybeMap(
@@ -214,7 +249,7 @@ class JournalImageCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(8.0),
           child: GFListTile(
             margin: EdgeInsets.zero,
-            padding: const EdgeInsets.only(right: 16),
+            padding: const EdgeInsets.only(right: 8.0),
             avatar: LimitedBox(
               maxWidth: (MediaQuery.of(context).size.width / 2) - 40,
               child: CardImageWidget(

--- a/lotti/lib/widgets/pages/journal_page.dart
+++ b/lotti/lib/widgets/pages/journal_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
@@ -47,12 +48,18 @@ class _JournalPageState extends State<JournalPage> {
       .map((entryType) => MultiSelectItem<FilterBy?>(entryType, entryType.name))
       .toList();
 
-  final List<String> _allTypes = _entryTypes.map((e) => e.typeName).toList();
+  final List<String> allTypes = _entryTypes.map((e) => e.typeName).toList();
+  late List<String> types;
+  bool starredActive = false;
 
   @override
   void initState() {
     super.initState();
-    stream = _db.watchJournalEntities(types: _allTypes);
+    types = allTypes;
+    stream = _db.watchJournalEntities(
+      types: types,
+      starredStatuses: [true, false],
+    );
   }
 
   @override
@@ -77,42 +84,69 @@ class _JournalPageState extends State<JournalPage> {
                   return Scaffold(
                     appBar: AppBar(
                       backgroundColor: AppColors.headerBgColor,
-                      title: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 32.0),
-                        child: MultiSelectDialogField(
-                          items: _items,
-                          title: const Text('Entry Types'),
-                          selectedColor: Colors.blue,
-                          decoration: BoxDecoration(
-                            color: Colors.blue.withOpacity(0.1),
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(40)),
-                            border: Border.all(
-                              color: AppColors.entryBgColor,
-                              width: 2,
-                            ),
-                          ),
-                          buttonIcon: Icon(
-                            Icons.search,
-                            color: AppColors.entryBgColor,
-                          ),
-                          buttonText: Text(
-                            'Filter by Type',
-                            style: TextStyle(
-                              color: AppColors.entryBgColor,
-                              fontSize: 16,
-                            ),
-                          ),
-                          onConfirm: (List<FilterBy?> results) {
-                            final List<String> types = results.isNotEmpty
-                                ? results.map((e) => e?.typeName ?? '').toList()
-                                : _allTypes;
+                      title: Row(
+                        children: [
+                          Expanded(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16.0),
+                              child: MultiSelectDialogField(
+                                items: _items,
+                                title: const Text('Entry Types'),
+                                selectedColor: Colors.blue,
+                                decoration: BoxDecoration(
+                                  color: Colors.blue.withOpacity(0.1),
+                                  borderRadius: const BorderRadius.all(
+                                      Radius.circular(40)),
+                                  border: Border.all(
+                                    color: AppColors.entryBgColor,
+                                    width: 2,
+                                  ),
+                                ),
+                                buttonIcon: Icon(
+                                  Icons.search,
+                                  color: AppColors.entryBgColor,
+                                ),
+                                buttonText: Text(
+                                  'Filter by Type',
+                                  style: TextStyle(
+                                    color: AppColors.entryBgColor,
+                                    fontSize: 16,
+                                  ),
+                                ),
+                                onConfirm: (List<FilterBy?> results) {
+                                  types = results.isNotEmpty
+                                      ? results
+                                          .map((e) => e?.typeName ?? '')
+                                          .toList()
+                                      : allTypes;
 
-                            setState(() {
-                              stream = _db.watchJournalEntities(types: types);
-                            });
-                          },
-                        ),
+                                  setState(() {
+                                    stream = _db.watchJournalEntities(
+                                      types: types,
+                                      starredStatuses: starredActive
+                                          ? [true]
+                                          : [true, false],
+                                    );
+                                  });
+                                },
+                              ),
+                            ),
+                          ),
+                          CupertinoSwitch(
+                            value: starredActive,
+                            onChanged: (bool value) {
+                              setState(() {
+                                starredActive = value;
+                                stream = _db.watchJournalEntities(
+                                  types: types,
+                                  starredStatuses:
+                                      starredActive ? [true] : [true, false],
+                                );
+                              });
+                            },
+                          ),
+                        ],
                       ),
                       centerTitle: true,
                     ),

--- a/lotti/lib/widgets/pages/journal_page.dart
+++ b/lotti/lib/widgets/pages/journal_page.dart
@@ -139,10 +139,11 @@ class _JournalPageState extends State<JournalPage> {
                             ),
                           ),
                           CupertinoSwitch(
-                            value: starredActive,
+                            value: privateActive,
+                            activeColor: AppColors.private,
                             onChanged: (bool value) {
                               setState(() {
-                                starredActive = value;
+                                privateActive = value;
                                 stream = _db.watchJournalEntities(
                                   types: types,
                                   starredStatuses:
@@ -154,10 +155,11 @@ class _JournalPageState extends State<JournalPage> {
                             },
                           ),
                           CupertinoSwitch(
-                            value: privateActive,
+                            value: starredActive,
+                            activeColor: AppColors.starredGold,
                             onChanged: (bool value) {
                               setState(() {
-                                privateActive = value;
+                                starredActive = value;
                                 stream = _db.watchJournalEntities(
                                   types: types,
                                   starredStatuses:

--- a/lotti/lib/widgets/pages/journal_page.dart
+++ b/lotti/lib/widgets/pages/journal_page.dart
@@ -51,6 +51,7 @@ class _JournalPageState extends State<JournalPage> {
   final List<String> allTypes = _entryTypes.map((e) => e.typeName).toList();
   late List<String> types;
   bool starredActive = false;
+  bool privateActive = false;
 
   @override
   void initState() {
@@ -59,6 +60,7 @@ class _JournalPageState extends State<JournalPage> {
     stream = _db.watchJournalEntities(
       types: types,
       starredStatuses: [true, false],
+      privateStatuses: [false],
     );
   }
 
@@ -127,6 +129,9 @@ class _JournalPageState extends State<JournalPage> {
                                       starredStatuses: starredActive
                                           ? [true]
                                           : [true, false],
+                                      privateStatuses: privateActive
+                                          ? [true, false]
+                                          : [false],
                                     );
                                   });
                                 },
@@ -142,6 +147,23 @@ class _JournalPageState extends State<JournalPage> {
                                   types: types,
                                   starredStatuses:
                                       starredActive ? [true] : [true, false],
+                                  privateStatuses:
+                                      privateActive ? [true, false] : [false],
+                                );
+                              });
+                            },
+                          ),
+                          CupertinoSwitch(
+                            value: privateActive,
+                            onChanged: (bool value) {
+                              setState(() {
+                                privateActive = value;
+                                stream = _db.watchJournalEntities(
+                                  types: types,
+                                  starredStatuses:
+                                      starredActive ? [true] : [true, false],
+                                  privateStatuses:
+                                      privateActive ? [true, false] : [false],
                                 );
                               });
                             },

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.9.0"
+    version: "4.9.1"
   dart_geohash:
     dependency: "direct main"
     description:
@@ -371,7 +371,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.6"
+    version: "0.6.8"
   delta_markdown:
     dependency: "direct main"
     description:
@@ -513,7 +513,7 @@ packages:
       name: extended_image_library
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -639,7 +639,7 @@ packages:
       name: flutter_keyboard_visibility
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.1"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
@@ -934,7 +934,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   image_picker:
     dependency: transitive
     description:
@@ -948,14 +948,14 @@ packages:
       name: image_picker_for_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   intl:
     dependency: "direct main"
     description:
@@ -990,7 +990,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.4"
   just_audio:
     dependency: "direct main"
     description:
@@ -1249,28 +1249,28 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   pedantic:
     dependency: transitive
     description:
@@ -1536,7 +1536,7 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   sqflite_common:
     dependency: transitive
     description:
@@ -1550,7 +1550,7 @@ packages:
       name: sqlite3
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1606,14 +1606,14 @@ packages:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "19.4.41"
+    version: "19.4.42"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "19.4.41"
+    version: "19.4.42"
   synchronized:
     dependency: transitive
     description:
@@ -1711,21 +1711,21 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.17"
+    version: "6.0.18"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.13"
+    version: "6.0.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.13"
+    version: "6.0.14"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1753,7 +1753,7 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1781,7 +1781,7 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.10"
+    version: "2.2.11"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -1795,7 +1795,7 @@ packages:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   vm_service:
     dependency: transitive
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+261
+version: 0.3.45+262
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+262
+version: 0.3.45+263
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+263
+version: 0.3.45+264
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+260
+version: 0.3.45+261
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.44+259
+version: 0.3.45+260
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+264
+version: 0.3.45+265
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds controls for filtering by starred and private entries. The difference is that activating the starred filter shows only starred entries as opposed to all entries, starred and not starred. The private filter works the other way around. By default, private entries are hidden and are only shown when the filter is activated, in addition to the entries that are not private. The mechanics might still change, the UI will almost certainly change after gaining some experience with these controls.