### PR TITLE
Move entry details header to separate widget

### DIFF
--- a/lotti/lib/widgets/journal/entry_detail_header.dart
+++ b/lotti/lib/widgets/journal/entry_detail_header.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/blocs/journal/persistence_cubit.dart';
+import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/main.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/journal/entry_datetime_modal.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:lotti/widgets/misc/map_widget.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:provider/src/provider.dart';
+
+class EntryDetailHeader extends StatefulWidget {
+  final JournalEntity item;
+  const EntryDetailHeader({
+    Key? key,
+    required this.item,
+  }) : super(key: key);
+
+  @override
+  State<EntryDetailHeader> createState() => _EntryDetailHeaderState();
+}
+
+class _EntryDetailHeaderState extends State<EntryDetailHeader> {
+  bool showDetails = false;
+  bool mapVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Geolocation? loc = widget.item.geolocation;
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            TextButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(
+                      top: Radius.circular(16),
+                    ),
+                  ),
+                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                  builder: (BuildContext context) {
+                    return EntryDateTimeModal(
+                      item: widget.item,
+                    );
+                  },
+                );
+              },
+              child: Text(
+                df.format(widget.item.meta.dateFrom),
+                style: textStyle,
+              ),
+            ),
+            Visibility(
+              visible: loc != null && loc.longitude != 0,
+              child: TextButton(
+                onPressed: () => setState(() {
+                  mapVisible = !mapVisible;
+                }),
+                child: Text(
+                  '📍 ${formatLatLon(loc?.latitude)}, '
+                  '${formatLatLon(loc?.longitude)}',
+                  style: textStyle,
+                ),
+              ),
+            ),
+            IconButton(
+              icon: Icon(showDetails
+                  ? MdiIcons.chevronDoubleUp
+                  : MdiIcons.chevronDoubleDown),
+              iconSize: 24,
+              tooltip: 'Details',
+              color: AppColors.appBarFgColor,
+              onPressed: () {
+                setState(() {
+                  showDetails = !showDetails;
+                });
+              },
+            ),
+          ],
+        ),
+        Visibility(
+          visible: showDetails,
+          child: EntryInfoRow(entityId: widget.item.meta.id),
+        ),
+        Visibility(
+          visible: mapVisible,
+          child: MapWidget(
+            geolocation: widget.item.geolocation,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class EntryInfoRow extends StatelessWidget {
+  final String entityId;
+  final JournalDb db = getIt<JournalDb>();
+
+  late final Stream<JournalEntity?> stream = db.watchEntityById(entityId);
+
+  EntryInfoRow({
+    Key? key,
+    required this.entityId,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<JournalEntity?>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<JournalEntity?> snapshot,
+        ) {
+          JournalEntity? liveEntity = snapshot.data;
+          if (liveEntity == null) {
+            return const SizedBox.shrink();
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SwitchRow(
+                label: 'Starred:',
+                onChanged: (bool value) {
+                  Metadata newMeta = liveEntity.meta.copyWith(
+                    starred: value,
+                  );
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntity(liveEntity, newMeta);
+                },
+                value: liveEntity.meta.starred ?? false,
+              ),
+              SwitchRow(
+                label: 'Private:',
+                onChanged: (bool value) {
+                  Metadata newMeta = liveEntity.meta.copyWith(
+                    private: value,
+                  );
+                  context
+                      .read<PersistenceCubit>()
+                      .updateJournalEntity(liveEntity, newMeta);
+                },
+                value: liveEntity.meta.private ?? false,
+              ),
+              SwitchRow(
+                label: 'Deleted:',
+                onChanged: (bool value) {
+                  if (value) {
+                    context
+                        .read<PersistenceCubit>()
+                        .deleteJournalEntity(liveEntity);
+                    Navigator.pop(context);
+                  }
+                },
+                value: liveEntity.meta.deletedAt != null,
+              ),
+            ],
+          );
+        });
+  }
+}
+
+class SwitchRow extends StatelessWidget {
+  const SwitchRow({
+    Key? key,
+    required this.label,
+    required this.onChanged,
+    required this.value,
+  }) : super(key: key);
+
+  final String label;
+  final void Function(bool)? onChanged;
+  final bool value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(label, style: textStyle),
+          CupertinoSwitch(value: value, onChanged: onChanged),
+        ],
+      ),
+    );
+  }
+}

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -7,18 +7,13 @@ import 'package:lotti/blocs/journal/persistence_cubit.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
-import 'package:lotti/main.dart';
-import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
 import 'package:lotti/widgets/journal/editor_widget.dart';
-import 'package:lotti/widgets/journal/entry_datetime_modal.dart';
+import 'package:lotti/widgets/journal/entry_detail_header.dart';
 import 'package:lotti/widgets/journal/entry_image_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
-import 'package:lotti/widgets/misc/map_widget.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/src/provider.dart';
 
@@ -63,70 +58,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
       children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            TextButton(
-              onPressed: () {
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.vertical(
-                      top: Radius.circular(16),
-                    ),
-                  ),
-                  clipBehavior: Clip.antiAliasWithSaveLayer,
-                  builder: (BuildContext context) {
-                    return EntryDateTimeModal(
-                      item: widget.item,
-                    );
-                  },
-                );
-              },
-              child: Text(
-                df.format(widget.item.meta.dateFrom),
-                style: textStyle,
-              ),
-            ),
-            Visibility(
-              visible: loc != null && loc.longitude != 0,
-              child: TextButton(
-                onPressed: () => setState(() {
-                  mapVisible = !mapVisible;
-                }),
-                child: Text(
-                  '📍 ${formatLatLon(loc?.latitude)}, '
-                  '${formatLatLon(loc?.longitude)}',
-                  style: textStyle,
-                ),
-              ),
-            ),
-            IconButton(
-              icon: Icon(showDetails
-                  ? MdiIcons.chevronDoubleUp
-                  : MdiIcons.chevronDoubleDown),
-              iconSize: 24,
-              tooltip: 'Details',
-              color: AppColors.appBarFgColor,
-              onPressed: () {
-                setState(() {
-                  showDetails = !showDetails;
-                });
-              },
-            ),
-          ],
-        ),
-        Visibility(
-          visible: showDetails,
-          child: EntryInfoRow(entityId: widget.item.meta.id),
-        ),
-        Visibility(
-          visible: mapVisible,
-          child: MapWidget(
-            geolocation: widget.item.geolocation,
-          ),
-        ),
+        EntryDetailHeader(item: widget.item),
         widget.item.maybeMap(
           journalAudio: (JournalAudio audio) {
             QuillController _controller =
@@ -239,103 +171,6 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           orElse: () => Container(),
         ),
       ],
-    );
-  }
-}
-
-class EntryInfoRow extends StatelessWidget {
-  final String entityId;
-  final JournalDb db = getIt<JournalDb>();
-
-  late final Stream<JournalEntity?> stream = db.watchEntityById(entityId);
-
-  EntryInfoRow({
-    Key? key,
-    required this.entityId,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<JournalEntity?>(
-        stream: stream,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<JournalEntity?> snapshot,
-        ) {
-          JournalEntity? liveEntity = snapshot.data;
-          if (liveEntity == null) {
-            return const SizedBox.shrink();
-          }
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              SwitchRow(
-                label: 'Starred:',
-                onChanged: (bool value) {
-                  Metadata newMeta = liveEntity.meta.copyWith(
-                    starred: value,
-                  );
-                  context
-                      .read<PersistenceCubit>()
-                      .updateJournalEntity(liveEntity, newMeta);
-                },
-                value: liveEntity.meta.starred ?? false,
-              ),
-              SwitchRow(
-                label: 'Private:',
-                onChanged: (bool value) {
-                  Metadata newMeta = liveEntity.meta.copyWith(
-                    private: value,
-                  );
-                  context
-                      .read<PersistenceCubit>()
-                      .updateJournalEntity(liveEntity, newMeta);
-                },
-                value: liveEntity.meta.private ?? false,
-              ),
-              SwitchRow(
-                label: 'Deleted:',
-                onChanged: (bool value) {
-                  if (value) {
-                    context
-                        .read<PersistenceCubit>()
-                        .deleteJournalEntity(liveEntity);
-                    Navigator.pop(context);
-                  }
-                },
-                value: liveEntity.meta.deletedAt != null,
-              ),
-            ],
-          );
-        });
-  }
-}
-
-class SwitchRow extends StatelessWidget {
-  const SwitchRow({
-    Key? key,
-    required this.label,
-    required this.onChanged,
-    required this.value,
-  }) : super(key: key);
-
-  final String label;
-  final void Function(bool)? onChanged;
-  final bool value;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(label, style: textStyle),
-          CupertinoSwitch(value: value, onChanged: onChanged),
-        ],
-      ),
     );
   }
 }

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.45+265
+version: 0.3.46+266
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR prevents overwriting the entry text when setting starred or private statuses.