### PR TITLE
Don't record geolocation when adding historic measurements

### DIFF
--- a/lotti/lib/blocs/journal/persistence_cubit.dart
+++ b/lotti/lib/blocs/journal/persistence_cubit.dart
@@ -135,11 +135,15 @@ class PersistenceCubit extends Cubit<PersistenceState> {
       VectorClock vc = await _vectorClockService.getNextVectorClock();
       String id = uuid.v5(Uuid.NAMESPACE_NIL, json.encode(data));
 
-      Geolocation? geolocation =
-          await location?.getCurrentGeoLocation().timeout(
-                const Duration(seconds: 5),
-                onTimeout: () => null, // TODO: report timeout in Insights
-              );
+      Geolocation? geolocation;
+
+      if (data.dateFrom.difference(DateTime.now()).inMinutes.abs() < 1 &&
+          data.dateTo.difference(DateTime.now()).inMinutes.abs() < 1) {
+        geolocation = await location?.getCurrentGeoLocation().timeout(
+              const Duration(seconds: 5),
+              onTimeout: () => null, // TODO: report timeout in Insights
+            );
+      }
 
       JournalEntity journalEntity = JournalEntity.measurement(
         data: data,

--- a/lotti/lib/widgets/pages/journal_page.dart
+++ b/lotti/lib/widgets/pages/journal_page.dart
@@ -88,7 +88,6 @@ class _JournalPageState extends State<JournalPage> {
     Set<String>? entryIds;
     for (TagDefinition tag in tags) {
       Set<String> entryIdsForTag = (await _db.entryIdsByTagId(tag.id)).toSet();
-      debugPrint('entryIdsForTag: $entryIdsForTag');
       if (entryIds == null) {
         entryIds = entryIdsForTag;
       } else {

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.64+317
+version: 0.3.65+318
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes recording the geolocation when recording past measurements (longer than one minute ago), as we cannot know where the device actually was at the time.