### PR TITLE
Import edited files, increase number

### DIFF
--- a/lotti/lib/blocs/journal/journal_image_cubit.dart
+++ b/lotti/lib/blocs/journal/journal_image_cubit.dart
@@ -26,6 +26,7 @@ class JournalImageCubit extends Cubit<JournalImageState> {
   Future<void> pickImageAssets(BuildContext context) async {
     final List<AssetEntity>? assets = await AssetPicker.pickAssets(
       context,
+      maxAssets: 40,
       textDelegate: EnglishTextDelegate(),
       routeDuration: const Duration(seconds: 0),
     );
@@ -45,11 +46,11 @@ class JournalImageCubit extends Cubit<JournalImageState> {
         }
 
         DateTime createdAt = asset.createDateTime;
-        File? originFile = await asset.originFile;
+        File? file = await asset.file;
 
-        if (originFile != null) {
+        if (file != null) {
           String idNamePart = asset.id.split('/').first;
-          String originalName = originFile.path.split('/').last;
+          String originalName = file.path.split('/').last;
           String imageFileName = '$idNamePart.$originalName'
               .replaceAll(
                 'HEIC',
@@ -64,7 +65,7 @@ class JournalImageCubit extends Cubit<JournalImageState> {
           String directory =
               await AudioUtils.createAssetDirectory(relativePath);
           String targetFilePath = '$directory$imageFileName';
-          await compressAndSave(originFile, targetFilePath);
+          await compressAndSave(file, targetFilePath);
           DateTime created = asset.createDateTime;
 
           ImageData imageData = ImageData(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.66+319
+version: 0.3.67+320
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes the imports to use edited photos from the camera roll, not the original, so that the imports are rotated, cropped etc as expected. Also increase the number of photos that can be selected to 40.