### PR TITLE
Avoid creating sync entry for existing entity

### DIFF
--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -105,7 +105,7 @@ class JournalDb extends _$JournalDb {
     if (!exists) {
       return upsertJournalDbEntity(dbEntity);
     } else {
-      debugPrint('PersistenceDb already exists: ${dbEntity.id}');
+      return 0;
     }
   }
 

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.3.86+368
+version: 0.3.87+369
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a check to only sync new entries, not existing ones, e.g. from health.