### PR TITLE
Disable screenshots in meins by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meins",
-  "version": "0.6.371",
+  "version": "0.6.372",
   "description": "meins - a personal information manager",
   "main": "prod/main-shadow/main.js",
   "scripts": {

--- a/src/cljs/meins/electron/main/menu.cljs
+++ b/src/cljs/meins/electron/main/menu.cljs
@@ -332,7 +332,7 @@
   {})
 
 (defn state-fn [put-fn]
-  (let [state (atom {:global-screenshots true})
+  (let [state (atom {:global-screenshots false})
         put-fn (fn [msg]
                  (let [msg-meta (merge {:window-id :active} (meta msg))]
                    (put-fn (with-meta msg msg-meta))))


### PR DESCRIPTION
This PR disables screenshots in `meins` by default. This is not required any longer, since Lotti can now take screenshots.