### PR TITLE
Remove limit for editor maximum height by default

### DIFF
--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -9,7 +9,7 @@ class EditorWidget extends StatelessWidget {
     Key? key,
     required QuillController controller,
     double minHeight = 80,
-    double? maxHeight,
+    double maxHeight = double.maxFinite,
     double padding = 16.0,
     bool readOnly = false,
     required Function saveFn,
@@ -24,7 +24,7 @@ class EditorWidget extends StatelessWidget {
         super(key: key);
 
   final QuillController _controller;
-  final double? _maxHeight;
+  final double _maxHeight;
   final double _minHeight;
   final bool _readOnly;
   final double _padding;
@@ -64,7 +64,7 @@ class EditorWidget extends StatelessWidget {
         color: AppColors.editorBgColor,
         child: ConstrainedBox(
           constraints: BoxConstraints(
-            maxHeight: _maxHeight ?? MediaQuery.of(context).size.height - 160,
+            maxHeight: _maxHeight,
           ),
           child: Column(
             mainAxisSize: MainAxisSize.min,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.4.11+423
+version: 0.4.12+424
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes the default height limitation for the entry editor, which does not serve a purpose any more, and makes scrolling long tex entries cumbersome because of the resulting nested scrolls.