### PR TITLE
Pass linked entry on recording start, not stop

### DIFF
--- a/lotti/lib/widgets/audio/audio_recorder.dart
+++ b/lotti/lib/widgets/audio/audio_recorder.dart
@@ -41,7 +41,8 @@ class AudioRecorderWidget extends StatelessWidget {
                 color: state.status == AudioRecorderStatus.recording
                     ? AppColors.activeAudioControl
                     : AppColors.inactiveAudioControl,
-                onPressed: () => context.read<AudioRecorderCubit>().record(),
+                onPressed: () =>
+                    context.read<AudioRecorderCubit>().record(linked: linked),
               ),
               IconButton(
                 icon: const Icon(Icons.stop),
@@ -49,7 +50,7 @@ class AudioRecorderWidget extends StatelessWidget {
                 tooltip: 'Stop',
                 color: AppColors.inactiveAudioControl,
                 onPressed: () {
-                  context.read<AudioRecorderCubit>().stop(linked: linked);
+                  context.read<AudioRecorderCubit>().stop();
                   Navigator.pop(context);
                 },
               ),

--- a/lotti/lib/widgets/create/add_actions.dart
+++ b/lotti/lib/widgets/create/add_actions.dart
@@ -167,7 +167,9 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
                 },
               ),
             );
-            context.read<AudioRecorderCubit>().record();
+            context.read<AudioRecorderCubit>().record(
+                  linked: widget.linked,
+                );
           },
         ),
       );

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.4.12+424
+version: 0.4.13+425
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR moves passing a linked entry from stopping the recording to starting the recording. This allows linking when stopping the recording from the new bottom recording indicator.