### PR TITLE
Add config flag for showing desktop notifications

### DIFF
--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -331,6 +331,13 @@ class JournalDb extends _$JournalDb {
           status: true,
         ),
       );
+      into(configFlags).insert(
+        ConfigFlag(
+          name: 'enable_notifications',
+          description: 'Enable desktop notifications?',
+          status: false,
+        ),
+      );
     }
   }
 

--- a/lotti/lib/services/notification_service.dart
+++ b/lotti/lib/services/notification_service.dart
@@ -4,11 +4,15 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/main.dart';
 
+final JournalDb _db = getIt<JournalDb>();
+
 class NotificationService {
   static FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
 
   static Future<void> updateBadge() async {
+    bool notifyEnabled = await _db.getConfigFlag('enable_notifications');
+
     if (Platform.isWindows || Platform.isLinux) {
       return;
     }
@@ -31,8 +35,7 @@ class NotificationService {
           sound: true,
         );
 
-    final JournalDb _journalDb = getIt<JournalDb>();
-    int counter = await _journalDb.getCountImportFlagEntries();
+    int counter = await _db.getCountImportFlagEntries();
     if (counter == 0) {
       flutterLocalNotificationsPlugin.show(
         1,
@@ -69,7 +72,7 @@ class NotificationService {
           badgeNumber: counter,
         ),
         macOS: MacOSNotificationDetails(
-          presentAlert: true,
+          presentAlert: notifyEnabled,
           presentBadge: true,
           badgeNumber: counter,
         ),

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.4.18+431
+version: 0.4.19+432
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a switch for desktop notifications in the form of a config flag. These notifications can become overwhelming when a lot of entries get imported from sync.