### PR TITLE
Remove newly redundant Windows config flag

### DIFF
--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           flutter-version: '2.10'
           channel: 'stable'
-      - name: Enable Windows Desktop
-        working-directory: ./lotti
-        run: flutter config --enable-windows-desktop
       - name: Flutter Doctor
         working-directory: ./lotti
         run: make doctor


### PR DESCRIPTION
This PR removes a config flag for Windows, which is not necessary in Flutter 2.10 any longer.