### PR TITLE
Add integration test for adding and deleting tag

### DIFF
--- a/lotti/integration_test/home_integration_test.dart
+++ b/lotti/integration_test/home_integration_test.dart
@@ -1,22 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:lotti/main.dart' as app;
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+
+const debug = false;
+
+Future<void> waitSeconds(int s) async {
+  if (debug) {
+    await Future.delayed(Duration(seconds: s), () {});
+  }
+}
 
 void main() {
   app.main();
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group(
-    'end-to-end test',
+    'new entry end-to-end test',
     () {
       testWidgets(
-        'tap settings bottom nav icon, verify settings elements',
+        'tap add, create entry',
         (WidgetTester tester) async {
           await tester.pumpAndSettle();
-          await Future.delayed(const Duration(seconds: 1), () {});
+
+          await waitSeconds(1);
 
           expect(find.text('Search...'), findsWidgets);
+
+          final Finder add = find.byIcon(Icons.add).first;
+          await tester.tap(add);
+          await tester.pumpAndSettle();
+
+          final Finder addText = find.byIcon(MdiIcons.textLong).first;
+          await tester.tap(addText);
+          await tester.pumpAndSettle();
+
+          Finder editor = find.byType(QuillEditor);
+          debugPrint(editor.toString());
+
+          // TODO: figure out how to enter text in flutter_quill
+          // String testText = 'test text: ${DateTime.now()}';
+          // await tester.enterText(editor, testText);
+
+          await waitSeconds(1);
+
+          final Finder saveIcon = find.byIcon(Icons.save);
+          await tester.tap(saveIcon);
+          await tester.pumpAndSettle();
+
+          //expect(find.text(testText), findsOneWidget);
+
+          await waitSeconds(1);
 
           final Finder settings = find.byIcon(Icons.settings_outlined);
           await tester.tap(settings);
@@ -32,7 +68,42 @@ void main() {
           expect(find.text('Flags'), findsOneWidget);
           expect(find.text('Maintenance'), findsOneWidget);
 
+          await tester.tap(find.byIcon(MdiIcons.tag));
+          await tester.pumpAndSettle();
+
+          await waitSeconds(1);
+
+          await tester.tap(find.byKey(const Key('add_tag_action')));
+          await tester.pumpAndSettle();
+
+          await waitSeconds(1);
+
+          await tester.tap(find.byIcon(MdiIcons.tagPlusOutline));
+          await tester.pumpAndSettle();
+
+          await waitSeconds(1);
+
+          String testTag = DateTime.now().toString();
+
+          await tester.enterText(
+              find.byKey(const Key('tag_name_field')), testTag);
           await Future.delayed(const Duration(seconds: 1), () {});
+
+          await tester.tap(find.byKey(const Key('tag_save')));
+          await tester.pumpAndSettle();
+
+          expect(find.text(testTag), findsOneWidget);
+          await waitSeconds(1);
+
+          await tester.tap(find.text(testTag));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byIcon(MdiIcons.trashCanOutline));
+          await tester.pumpAndSettle();
+
+          expect(find.text(testTag), findsNothing);
+
+          await waitSeconds(2);
         },
       );
     },

--- a/lotti/ios/Podfile.lock
+++ b/lotti/ios/Podfile.lock
@@ -47,6 +47,8 @@ PODS:
     - Flutter
   - image_picker (0.0.1):
     - Flutter
+  - integration_test (0.0.1):
+    - Flutter
   - just_audio (0.0.1):
     - Flutter
   - libwebp (1.2.1):
@@ -129,6 +131,7 @@ DEPENDENCIES:
   - gallery_saver (from `.symlinks/plugins/gallery_saver/ios`)
   - health (from `.symlinks/plugins/health/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/ios`)
   - location (from `.symlinks/plugins/location/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -190,6 +193,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/health/ios"
   image_picker:
     :path: ".symlinks/plugins/image_picker/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/ios"
   location:
@@ -233,6 +238,7 @@ SPEC CHECKSUMS:
   gallery_saver: 9fc173c9f4fcc48af53b2a9ebea1b643255be542
   health: e7a5807e45ec58fe6b89a730c97abc6caafe94a0
   image_picker: 541dcbb3b9cf32d87eacbd957845d8651d6c62c3
+  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
   libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc
   location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740

--- a/lotti/lib/widgets/create/add_tag_actions.dart
+++ b/lotti/lib/widgets/create/add_tag_actions.dart
@@ -31,6 +31,7 @@ class _RadialAddTagButtonsState extends State<RadialAddTagButtons> {
     List<Widget> items = [
       FloatingActionButton(
         heroTag: 'tag',
+        key: const Key('add_tag_action'),
         child: const Icon(
           MdiIcons.tagPlusOutline,
           size: 32,

--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -197,6 +197,8 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                           minutes: dt.minute,
                         );
 
+                        HapticFeedback.heavyImpact();
+
                         TaskData updatedData = task.data.copyWith(
                           title: title,
                           estimate: estimate,

--- a/lotti/lib/widgets/pages/settings/tags/tag_details.dart
+++ b/lotti/lib/widgets/pages/settings/tags/tag_details.dart
@@ -40,6 +40,7 @@ class _TagDetailRouteState extends State<TagDetailRoute> {
         ),
         actions: <Widget>[
           TextButton(
+            key: const Key('tag_save'),
             onPressed: () async {
               _formKey.currentState!.save();
               if (_formKey.currentState!.validate()) {
@@ -128,6 +129,7 @@ class _TagDetailRouteState extends State<TagDetailRoute> {
                             initialValue: widget.tagEntity.tag,
                             labelText: 'Tag',
                             name: 'tag',
+                            key: const Key('tag_name_field'),
                           ),
                           FormBuilderSwitch(
                             name: 'private',


### PR DESCRIPTION
This test adds an integration test for adding and deleting a tag. Needs more work in terms of structuring the tests. Also, unclear at this point how to enter text in `quill_editor` within a test. Also, tests crashing when using multiple `testWidgets`, hence only one that's way too long.