### PR TITLE
Fix clipped progress indicator

### DIFF
--- a/lotti/lib/widgets/journal/linked_duration.dart
+++ b/lotti/lib/widgets/journal/linked_duration.dart
@@ -53,20 +53,23 @@ class LinkedDuration extends StatelessWidget {
                   child: SizedBox(
                     width: MediaQuery.of(context).size.width - 80,
                     child: ClipRRect(
-                      child: ProgressBar(
-                        progress: progress,
-                        total: total,
-                        progressBarColor:
-                            (progress >= total) ? Colors.red : Colors.green,
-                        thumbColor: Colors.white,
-                        barHeight: 8.0,
-                        thumbRadius: 8.0,
-                        onSeek: (newPosition) {},
-                        timeLabelTextStyle: TextStyle(
-                          fontFamily: 'Oswald',
-                          color: AppColors.entryTextColor,
-                          fontWeight: FontWeight.normal,
-                          fontSize: 14.0,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 4.0),
+                        child: ProgressBar(
+                          progress: progress,
+                          total: total,
+                          progressBarColor:
+                              (progress >= total) ? Colors.red : Colors.green,
+                          thumbColor: Colors.white,
+                          barHeight: 8.0,
+                          thumbRadius: 8.0,
+                          onSeek: (newPosition) {},
+                          timeLabelTextStyle: TextStyle(
+                            fontFamily: 'Oswald',
+                            color: AppColors.entryTextColor,
+                            fontWeight: FontWeight.normal,
+                            fontSize: 14.0,
+                          ),
                         ),
                       ),
                     ),

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.5.6+470
+version: 0.5.7+471
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes the progress bar for tasks, which was previously clipped by a few pixels on the left when progress was at zero.