### PR TITLE
Auto close radial action button after 5 seconds

### DIFF
--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -1509,8 +1509,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f91a5e3
-      resolved-ref: f91a5e3fc350a9408aa625bdbd8593c1fc893cd9
+      ref: "3137f03"
+      resolved-ref: "3137f03fef0637913976c13c931a6aa14d7ca489"
       url: "https://github.com/matthiasn/radial_button"
     source: git
     version: "0.1.5"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.5.14+497
+version: 0.5.15+498
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -32,7 +32,7 @@ dependencies:
   radial_button:
     git:
       url: https://github.com/matthiasn/radial_button
-      ref: f91a5e3
+      ref: 3137f03
 
   # enough_mail: ^1.3.6
   # delta_markdown: ^0.4.0


### PR DESCRIPTION
This PR adds closing the radial action buttons in an attempt to make interaction less annoying after popping from stack. Hardcoded 5 seconds in the fork. Should be configurable, but first determine if useful.