### PR TITLE
Re-enable updating task text only

### DIFF
--- a/lotti/lib/widgets/journal/entry_detail_widget.dart
+++ b/lotti/lib/widgets/journal/entry_detail_widget.dart
@@ -201,6 +201,12 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                         formKey.currentState?.save();
                         final formData = formKey.currentState?.value;
                         if (formData == null) {
+                          persistenceLogic.updateTask(
+                            entryText: entryTextFromController(_controller),
+                            journalEntityId: task.meta.id,
+                            taskData: task.data,
+                          );
+
                           return;
                         }
                         final DateTime due = formData['due'];

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.5.22+518
+version: 0.5.23+519
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes saving changed text in a task, without having opened/edited title, estimate, or status.