### PR TITLE
Render charts even when empty

### DIFF
--- a/lotti/lib/widgets/charts/dashboard_health_bmi_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_health_bmi_chart.dart
@@ -61,11 +61,7 @@ class DashboardHealthBmiChart extends StatelessWidget {
             BuildContext context,
             AsyncSnapshot<List<JournalEntity?>> snapshot,
           ) {
-            List<JournalEntity?>? items = snapshot.data;
-
-            if (items == null || items.isEmpty) {
-              return const SizedBox.shrink();
-            }
+            List<JournalEntity?>? items = snapshot.data ?? [];
 
             List<Observation> weightData = aggregateNone(items);
 

--- a/lotti/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_health_chart.dart
@@ -83,11 +83,7 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
         BuildContext context,
         AsyncSnapshot<List<JournalEntity?>> snapshot,
       ) {
-        List<JournalEntity?>? items = snapshot.data;
-
-        if (items == null || items.isEmpty) {
-          return const SizedBox.shrink();
-        }
+        List<JournalEntity?>? items = snapshot.data ?? [];
 
         List<charts.Series<Observation, DateTime>> seriesList = [
           charts.Series<Observation, DateTime>(

--- a/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -54,7 +54,8 @@ class DashboardMeasurablesChart extends StatelessWidget {
             BuildContext context,
             AsyncSnapshot<List<JournalEntity?>> measurementsSnapshot,
           ) {
-            List<JournalEntity?>? measurements = measurementsSnapshot.data;
+            List<JournalEntity?>? measurements =
+                measurementsSnapshot.data ?? [];
 
             charts.SeriesRendererConfig<DateTime>? defaultRenderer;
 
@@ -65,10 +66,6 @@ class DashboardMeasurablesChart extends StatelessWidget {
               );
             } else {
               defaultRenderer = charts.BarRendererConfig<DateTime>();
-            }
-
-            if (measurements == null || measurements.isEmpty) {
-              return const SizedBox.shrink();
             }
 
             void onDoubleTap() {

--- a/lotti/lib/widgets/charts/dashboard_story_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_story_chart.dart
@@ -55,11 +55,7 @@ class _DashboardStoryChartState extends State<DashboardStoryChart> {
         BuildContext context,
         AsyncSnapshot<List<JournalEntity?>> snapshot,
       ) {
-        List<JournalEntity?>? items = snapshot.data;
-
-        if (items == null || items.isEmpty) {
-          return const SizedBox.shrink();
-        }
+        List<JournalEntity?>? items = snapshot.data ?? [];
 
         List<Observation> data = aggregateStoryDailyTimeSum(
           items,

--- a/lotti/lib/widgets/charts/dashboard_survey_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_survey_chart.dart
@@ -45,11 +45,7 @@ class DashboardSurveyChart extends StatelessWidget {
         BuildContext context,
         AsyncSnapshot<List<JournalEntity?>> snapshot,
       ) {
-        List<JournalEntity?>? items = snapshot.data;
-
-        if (items == null || items.isEmpty) {
-          return const SizedBox.shrink();
-        }
+        List<JournalEntity?>? items = snapshot.data ?? [];
 
         void onDoubleTap() async {
           RPOrderedTask? task = surveyTasks[chartConfig.surveyType];

--- a/lotti/lib/widgets/charts/dashboard_workout_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_workout_chart.dart
@@ -52,11 +52,7 @@ class _DashboardWorkoutChartState extends State<DashboardWorkoutChart> {
         BuildContext context,
         AsyncSnapshot<List<JournalEntity?>> snapshot,
       ) {
-        List<JournalEntity?>? items = snapshot.data;
-
-        if (items == null || items.isEmpty) {
-          return const SizedBox.shrink();
-        }
+        List<JournalEntity?>? items = snapshot.data ?? [];
 
         List<charts.Series<Observation, DateTime>> seriesList = [
           charts.Series<Observation, DateTime>(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.5.29+532
+version: 0.5.30+533
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes the rendering of charts to always be rendered, even when no existing data available. This makes initial data entry more convenient when starting with a new dashboard with new measurable types.