### PR TITLE
Time recording indicator

### DIFF
--- a/lotti/lib/pages/home_page.dart
+++ b/lotti/lib/pages/home_page.dart
@@ -14,6 +14,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AutoTabsScaffold(
+      lazyLoad: false,
       animationDuration: const Duration(milliseconds: 500),
       appBarBuilder: (context, tabsRouter) => AppBar(
         backgroundColor: AppColors.headerBgColor,
@@ -23,6 +24,19 @@ class HomePage extends StatelessWidget {
           color: AppColors.entryTextColor,
         ),
       ),
+      builder: (context, child, _) {
+        return Container(
+          color: AppColors.bodyBgColor,
+          height: double.maxFinite,
+          width: double.maxFinite,
+          child: Stack(
+            children: [
+              child,
+              const TimeRecordingIndicator(),
+            ],
+          ),
+        );
+      },
       backgroundColor: AppColors.bodyBgColor,
       routes: const [
         JournalRouter(),
@@ -33,46 +47,39 @@ class HomePage extends StatelessWidget {
         SettingsRouter(),
       ],
       bottomNavigationBuilder: (_, tabsRouter) {
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TimeRecordingIndicatorWidget(),
-            BottomNavigationBar(
-              type: BottomNavigationBarType.fixed,
-              backgroundColor: AppColors.headerBgColor,
-              unselectedItemColor: AppColors.bottomNavIconUnselected,
-              selectedItemColor: AppColors.bottomNavIconSelected,
-              currentIndex: tabsRouter.activeIndex,
-              onTap: tabsRouter.setActiveIndex,
-              items: [
-                const BottomNavigationBarItem(
-                  icon: Icon(Icons.home_outlined),
-                  label: 'Journal',
-                ),
-                BottomNavigationBarItem(
-                  icon: FlaggedBadgeIcon(),
-                  label: 'Flagged',
-                ),
-                BottomNavigationBarItem(
-                  icon: TasksBadgeIcon(),
-                  label: 'Tasks',
-                ),
-                const BottomNavigationBarItem(
-                  icon: Icon(Icons.lightbulb_outline),
-                  label: 'Dashboards',
-                ),
-                const BottomNavigationBarItem(
-                  icon: Icon(Icons.calendar_today),
-                  label: 'My Day',
-                ),
-                BottomNavigationBarItem(
-                  icon: OutboxBadgeIcon(
-                    icon: const Icon(Icons.settings_outlined),
-                  ),
-                  label: 'Settings',
-                ),
-              ],
+        return BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          backgroundColor: AppColors.headerBgColor,
+          unselectedItemColor: AppColors.bottomNavIconUnselected,
+          selectedItemColor: AppColors.bottomNavIconSelected,
+          currentIndex: tabsRouter.activeIndex,
+          onTap: tabsRouter.setActiveIndex,
+          items: [
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.home_outlined),
+              label: 'Journal',
+            ),
+            BottomNavigationBarItem(
+              icon: FlaggedBadgeIcon(),
+              label: 'Flagged',
+            ),
+            BottomNavigationBarItem(
+              icon: TasksBadgeIcon(),
+              label: 'Tasks',
+            ),
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.lightbulb_outline),
+              label: 'Dashboards',
+            ),
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_today),
+              label: 'My Day',
+            ),
+            BottomNavigationBarItem(
+              icon: OutboxBadgeIcon(
+                icon: const Icon(Icons.settings_outlined),
+              ),
+              label: 'Settings',
             ),
           ],
         );

--- a/lotti/lib/pages/home_page.dart
+++ b/lotti/lib/pages/home_page.dart
@@ -6,6 +6,7 @@ import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/bottom_nav/flagged_badge_icon.dart';
 import 'package:lotti/widgets/bottom_nav/tasks_badge_icon.dart';
 import 'package:lotti/widgets/misc/app_bar_version.dart';
+import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -32,39 +33,46 @@ class HomePage extends StatelessWidget {
         SettingsRouter(),
       ],
       bottomNavigationBuilder: (_, tabsRouter) {
-        return BottomNavigationBar(
-          type: BottomNavigationBarType.fixed,
-          backgroundColor: AppColors.headerBgColor,
-          unselectedItemColor: AppColors.bottomNavIconUnselected,
-          selectedItemColor: AppColors.bottomNavIconSelected,
-          currentIndex: tabsRouter.activeIndex,
-          onTap: tabsRouter.setActiveIndex,
-          items: [
-            const BottomNavigationBarItem(
-              icon: Icon(Icons.home_outlined),
-              label: 'Journal',
-            ),
-            BottomNavigationBarItem(
-              icon: FlaggedBadgeIcon(),
-              label: 'Flagged',
-            ),
-            BottomNavigationBarItem(
-              icon: TasksBadgeIcon(),
-              label: 'Tasks',
-            ),
-            const BottomNavigationBarItem(
-              icon: Icon(Icons.lightbulb_outline),
-              label: 'Dashboards',
-            ),
-            const BottomNavigationBarItem(
-              icon: Icon(Icons.calendar_today),
-              label: 'My Day',
-            ),
-            BottomNavigationBarItem(
-              icon: OutboxBadgeIcon(
-                icon: const Icon(Icons.settings_outlined),
-              ),
-              label: 'Settings',
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TimeRecordingIndicatorWidget(),
+            BottomNavigationBar(
+              type: BottomNavigationBarType.fixed,
+              backgroundColor: AppColors.headerBgColor,
+              unselectedItemColor: AppColors.bottomNavIconUnselected,
+              selectedItemColor: AppColors.bottomNavIconSelected,
+              currentIndex: tabsRouter.activeIndex,
+              onTap: tabsRouter.setActiveIndex,
+              items: [
+                const BottomNavigationBarItem(
+                  icon: Icon(Icons.home_outlined),
+                  label: 'Journal',
+                ),
+                BottomNavigationBarItem(
+                  icon: FlaggedBadgeIcon(),
+                  label: 'Flagged',
+                ),
+                BottomNavigationBarItem(
+                  icon: TasksBadgeIcon(),
+                  label: 'Tasks',
+                ),
+                const BottomNavigationBarItem(
+                  icon: Icon(Icons.lightbulb_outline),
+                  label: 'Dashboards',
+                ),
+                const BottomNavigationBarItem(
+                  icon: Icon(Icons.calendar_today),
+                  label: 'My Day',
+                ),
+                BottomNavigationBarItem(
+                  icon: OutboxBadgeIcon(
+                    icon: const Icon(Icons.settings_outlined),
+                  ),
+                  label: 'Settings',
+                ),
+              ],
             ),
           ],
         );

--- a/lotti/lib/widgets/misc/time_recording_indicator.dart
+++ b/lotti/lib/widgets/misc/time_recording_indicator.dart
@@ -7,10 +7,10 @@ import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-class TimeRecordingIndicator extends StatelessWidget {
+class TimeRecordingIndicatorWidget extends StatelessWidget {
   final TimeService _timeService = getIt<TimeService>();
 
-  TimeRecordingIndicator({
+  TimeRecordingIndicatorWidget({
     Key? key,
   }) : super(key: key);
 
@@ -30,51 +30,62 @@ class TimeRecordingIndicator extends StatelessWidget {
 
         String durationString = formatDuration(entryDuration(current));
 
-        return Positioned(
-          left: 0,
-          bottom: 0,
-          child: GestureDetector(
-            onTap: () {
-              String entryId = current.meta.id;
-              context.router.pushNamed('/journal/$entryId');
-            },
-            child: MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: ClipRRect(
-                borderRadius: const BorderRadius.only(
-                  topRight: Radius.circular(8),
-                ),
-                child: Container(
-                  color: AppColors.timeRecordingBg,
-                  width: 110,
-                  height: 32,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        MdiIcons.timerOutline,
-                        color: AppColors.editorTextColor,
-                        size: 16,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(left: 4),
-                        child: Text(
-                          durationString,
-                          style: TextStyle(
-                            fontFamily: 'ShareTechMono',
-                            fontSize: 18.0,
-                            color: AppColors.editorTextColor,
-                          ),
+        return GestureDetector(
+          onTap: () {
+            String entryId = current.meta.id;
+            context.router.pushNamed('/journal/$entryId');
+          },
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ClipRRect(
+              borderRadius: const BorderRadius.only(
+                topRight: Radius.circular(8),
+              ),
+              child: Container(
+                color: AppColors.timeRecordingBg,
+                width: 110,
+                height: 32,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      MdiIcons.timerOutline,
+                      color: AppColors.editorTextColor,
+                      size: 16,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: Text(
+                        durationString,
+                        style: TextStyle(
+                          fontFamily: 'ShareTechMono',
+                          fontSize: 18.0,
+                          color: AppColors.editorTextColor,
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),
           ),
         );
       },
+    );
+  }
+}
+
+class TimeRecordingIndicator extends StatelessWidget {
+  const TimeRecordingIndicator({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 0,
+      bottom: 0,
+      child: TimeRecordingIndicatorWidget(),
     );
   }
 }

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.3+552
+version: 0.6.4+553
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.4+553
+version: 0.6.4+554
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR brings back the time recording indicator, rendered right above the bottom tab bar in the left corner. This widget is positioned there in a stack by the builder of the `AutoTabsScaffold`.