### PR TITLE
Use measurement route in create action

### DIFF
--- a/lotti/lib/logic/persistence_logic.dart
+++ b/lotti/lib/logic/persistence_logic.dart
@@ -160,7 +160,7 @@ class PersistenceLogic {
 
   Future<bool> createMeasurementEntry({
     required MeasurementData data,
-    JournalEntity? linked,
+    String? linkedId,
   }) async {
     final transaction =
         _insightsDb.startTransaction('createMeasurementEntry()', 'task');
@@ -197,7 +197,7 @@ class PersistenceLogic {
       await createDbEntity(
         journalEntity,
         enqueueSync: true,
-        linkedId: linked?.meta.id,
+        linkedId: linkedId,
       );
     } catch (exception, stackTrace) {
       await _insightsDb.captureException(exception, stackTrace: stackTrace);

--- a/lotti/lib/pages/add/new_measurement_page.dart
+++ b/lotti/lib/pages/add/new_measurement_page.dart
@@ -83,7 +83,7 @@ class _NewMeasurementPageState extends State<NewMeasurementPage> {
                     );
                     persistenceLogic.createMeasurementEntry(
                       data: measurement,
-                      linked: widget.linked,
+                      linkedId: widget.linked?.meta.id,
                     );
                     context.router.pop();
                   }

--- a/lotti/lib/pages/create/create_measurement_page.dart
+++ b/lotti/lib/pages/create/create_measurement_page.dart
@@ -1,0 +1,236 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/charts/dashboard_measurables_chart.dart';
+import 'package:lotti/widgets/charts/utils.dart';
+import 'package:lotti/widgets/form_builder/cupertino_datepicker.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+
+class CreateMeasurementPage extends StatefulWidget {
+  const CreateMeasurementPage({
+    Key? key,
+    this.linkedId,
+    this.selectedId,
+  }) : super(key: key);
+
+  final String? linkedId;
+  final String? selectedId;
+
+  @override
+  State<CreateMeasurementPage> createState() => _CreateMeasurementPageState();
+}
+
+class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
+  final JournalDb _db = getIt<JournalDb>();
+  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
+  final _formKey = GlobalKey<FormBuilderState>();
+
+  MeasurableDataType? selected;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<MeasurableDataType>>(
+      stream: _db.watchMeasurableDataTypes(),
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<List<MeasurableDataType>> snapshot,
+      ) {
+        List<MeasurableDataType> items = snapshot.data ?? [];
+
+        for (MeasurableDataType dataType in items) {
+          if (dataType.id == widget.selectedId) {
+            selected = dataType;
+          }
+        }
+
+        void onSave() async {
+          _formKey.currentState!.save();
+          if (_formKey.currentState!.validate()) {
+            final formData = _formKey.currentState?.value;
+            if (selected == null) {
+              return;
+            }
+            MeasurementData measurement = MeasurementData(
+              dataType: selected!,
+              dateTo: formData!['date'],
+              dateFrom: formData['date'],
+              value: nf.parse('${formData['value']}'.replaceAll(',', '.')),
+            );
+            persistenceLogic.createMeasurementEntry(
+              data: measurement,
+              linkedId: widget.linkedId,
+            );
+            context.router.pop();
+          }
+        }
+
+        return Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Container(
+                  color: AppColors.headerBgColor,
+                  padding: const EdgeInsets.all(32.0),
+                  child: FormBuilder(
+                    key: _formKey,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    child: Column(
+                      children: <Widget>[
+                        Text(
+                          selected?.displayName ?? 'New Measurement',
+                          style: TextStyle(
+                            color: AppColors.entryTextColor,
+                            fontFamily: 'Oswald',
+                          ),
+                        ),
+                        if (selected == null)
+                          FormBuilderDropdown(
+                            dropdownColor: AppColors.headerBgColor,
+                            name: 'type',
+                            decoration: InputDecoration(
+                              labelText: 'Type',
+                              labelStyle: labelStyle,
+                            ),
+                            hint: Text(
+                              'Select Measurement Type',
+                              style: inputStyle,
+                            ),
+                            onChanged: (MeasurableDataType? value) {
+                              setState(() {
+                                selected = value;
+                              });
+                            },
+                            validator: FormBuilderValidators.compose(
+                                [FormBuilderValidators.required(context)]),
+                            items: items
+                                .map((MeasurableDataType item) =>
+                                    DropdownMenuItem(
+                                      value: item,
+                                      child: Text(
+                                        item.displayName,
+                                        style: inputStyle,
+                                      ),
+                                    ))
+                                .toList(),
+                          ),
+                        if (selected != null)
+                          FormBuilderCupertinoDateTimePicker(
+                            name: 'date',
+                            alwaysUse24HourFormat: true,
+                            format:
+                                DateFormat('EEEE, MMMM d, yyyy \'at\' HH:mm'),
+                            inputType: CupertinoDateTimePickerInputType.both,
+                            style: inputStyle,
+                            decoration: InputDecoration(
+                              labelText: 'Measurement taken',
+                              labelStyle: labelStyle,
+                            ),
+                            initialValue: DateTime.now(),
+                            theme: DatePickerTheme(
+                              headerColor: AppColors.headerBgColor,
+                              backgroundColor: AppColors.bodyBgColor,
+                              itemStyle: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18,
+                              ),
+                              doneStyle: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                              ),
+                            ),
+                          ),
+                        if (selected != null)
+                          FormBuilderTextField(
+                            initialValue: '',
+                            decoration: InputDecoration(
+                              labelText: selected!.description,
+                              labelStyle: labelStyle,
+                            ),
+                            style: inputStyle,
+                            name: 'value',
+                            keyboardType: const TextInputType.numberWithOptions(
+                                decimal: true),
+                          ),
+                        TextButton(
+                          onPressed: onSave,
+                          child: Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 24.0),
+                            child: Text(
+                              'Save',
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontFamily: 'Oswald',
+                                fontWeight: FontWeight.bold,
+                                color: AppColors.appBarFgColor,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (selected != null)
+                DashboardMeasurablesChart(
+                  measurableDataTypeId: selected!.id,
+                  rangeStart: getRangeStart(context),
+                  rangeEnd: getRangeEnd(),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class CreateMeasurementWithLinkedPage extends StatelessWidget {
+  const CreateMeasurementWithLinkedPage({
+    Key? key,
+    @PathParam() this.linkedId,
+  }) : super(key: key);
+
+  final String? linkedId;
+
+  @override
+  Widget build(BuildContext context) {
+    return CreateMeasurementPage(
+      linkedId: linkedId,
+    );
+  }
+}
+
+class CreateMeasurementWithTypePage extends StatelessWidget {
+  const CreateMeasurementWithTypePage({
+    Key? key,
+    @PathParam() this.selectedId,
+  }) : super(key: key);
+
+  final String? selectedId;
+
+  @override
+  Widget build(BuildContext context) {
+    return CreateMeasurementPage(
+      selectedId: selectedId,
+    );
+  }
+}

--- a/lotti/lib/routes/journal_routes.dart
+++ b/lotti/lib/routes/journal_routes.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:lotti/pages/create/create_measurement_page.dart';
 import 'package:lotti/pages/create/create_text_entry_page.dart';
 import 'package:lotti/pages/create/fill_survey_page.dart';
 import 'package:lotti/pages/create/record_audio_page.dart';
@@ -29,6 +30,14 @@ const AutoRoute journalRoutes = AutoRoute(
     AutoRoute(
       path: 'record_audio/:linkedId',
       page: RecordAudioPage,
+    ),
+    AutoRoute(
+      path: 'create_measurement_linked/:linkedId',
+      page: CreateMeasurementWithLinkedPage,
+    ),
+    AutoRoute(
+      path: 'dashboard_add_measurement/:selectedId',
+      page: CreateMeasurementWithTypePage,
     ),
   ],
 );

--- a/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -70,6 +70,11 @@ class DashboardMeasurablesChart extends StatelessWidget {
 
             void onDoubleTap() {
               if (enableCreate) {
+                // String selectedId = measurableDataType.id;
+                // context.router
+                //     .pushNamed('journal/dashboard_add_measurement/$selectedId');
+
+                // TODO: fix above & remove code below
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (BuildContext context) {

--- a/lotti/lib/widgets/create/add_actions.dart
+++ b/lotti/lib/widgets/create/add_actions.dart
@@ -8,7 +8,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/image_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/pages/add/new_measurement_page.dart';
+import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/screenshots.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -71,15 +71,10 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
         ),
         backgroundColor: AppColors.actionColor,
         onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (BuildContext context) {
-                return NewMeasurementPage(
-                  linked: widget.linked,
-                );
-              },
-            ),
-          );
+          String? linkedId = widget.linked?.meta.id;
+          context.router.push(CreateMeasurementWithLinkedRoute(
+            linkedId: linkedId,
+          ));
         },
       ),
     );

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.4+554
+version: 0.6.5+555
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes new measurements from the radial action button to use `autoroute`. Currently unclear why this doesn't work when opening from dashboards.