### PR TITLE
Fix wrap constraints in tags widget

### DIFF
--- a/lotti/lib/widgets/journal/tags_widget.dart
+++ b/lotti/lib/widgets/journal/tags_widget.dart
@@ -285,7 +285,10 @@ class TagsListWidget extends StatelessWidget {
             }
 
             return ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 24),
+              constraints: BoxConstraints(
+                minHeight: 24,
+                maxWidth: MediaQuery.of(context).size.width - 80,
+              ),
               child: Wrap(
                   spacing: 4,
                   runSpacing: 4,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.7+561
+version: 0.6.8+562
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes wrapping tags in the tag editor widget.