### PR TITLE
Navigate to tag definition from tag chip on entry details

### DIFF
--- a/lotti/lib/routes/settings_routes.dart
+++ b/lotti/lib/routes/settings_routes.dart
@@ -31,7 +31,7 @@ const AutoRoute settingsRoutes = AutoRoute(
       page: TagsPage,
     ),
     AutoRoute(
-      path: 'tags/:tagId',
+      path: 'tags/:tagEntityId',
       page: EditExistingTagPage,
     ),
     AutoRoute(

--- a/lotti/lib/widgets/journal/tags_search_widget.dart
+++ b/lotti/lib/widgets/journal/tags_search_widget.dart
@@ -119,7 +119,7 @@ class SelectedTagsWidget extends StatelessWidget {
                 }
                 return TagWidget(
                   tagEntity: tagEntity,
-                  onTap: () {
+                  onTapRemove: () {
                     removeTag(tagEntity.id);
                   },
                 );

--- a/lotti/lib/widgets/journal/tags_view_widget.dart
+++ b/lotti/lib/widgets/journal/tags_view_widget.dart
@@ -46,31 +46,43 @@ class TagsViewWidget extends StatelessWidget {
                 spacing: 4,
                 runSpacing: 4,
                 children: tagsFromTagIds
-                    .map(
-                      (TagEntity tagEntity) => Padding(
-                        padding: const EdgeInsets.only(bottom: 1.0),
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(chipBorderRadius),
-                          child: Container(
-                            padding: chipPadding,
-                            color: getTagColor(tagEntity),
-                            child: Text(
-                              tagEntity.tag,
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontFamily: 'Oswald',
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    )
+                    .map((tagEntity) => TagChip(tagEntity))
                     .toList(),
               ),
             ],
           ),
         );
       },
+    );
+  }
+}
+
+class TagChip extends StatelessWidget {
+  final TagEntity tagEntity;
+
+  const TagChip(
+    this.tagEntity, {
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 1.0),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(chipBorderRadius),
+        child: Container(
+          padding: chipPadding,
+          color: getTagColor(tagEntity),
+          child: Text(
+            tagEntity.tag,
+            style: const TextStyle(
+              fontSize: 12,
+              fontFamily: 'Oswald',
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lotti/lib/widgets/journal/tags_widget.dart
+++ b/lotti/lib/widgets/journal/tags_widget.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
@@ -295,7 +296,7 @@ class TagsListWidget extends StatelessWidget {
                   children: tagsFromTagIds
                       .map((TagEntity tagEntity) => TagWidget(
                             tagEntity: tagEntity,
-                            onTap: () {
+                            onTapRemove: () {
                               removeTagId(tagEntity.id);
                             },
                           ))
@@ -312,45 +313,50 @@ class TagWidget extends StatelessWidget {
   const TagWidget({
     Key? key,
     required this.tagEntity,
-    required this.onTap,
+    required this.onTapRemove,
   }) : super(key: key);
 
   final TagEntity tagEntity;
-  final void Function()? onTap;
+  final void Function()? onTapRemove;
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(chipBorderRadius),
-      child: Container(
-        padding: chipPaddingClosable,
-        color: getTagColor(tagEntity),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              tagEntity.tag,
-              style: TextStyle(
-                fontSize: 14,
-                fontFamily: 'Oswald',
-                color: AppColors.tagTextColor,
-              ),
-            ),
-            MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 4.0),
-                  child: Icon(
-                    MdiIcons.close,
-                    size: 16,
-                    color: AppColors.tagTextColor,
-                  ),
+    return GestureDetector(
+      onDoubleTap: () {
+        context.router.pushNamed('/settings/tags/${tagEntity.id}');
+      },
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(chipBorderRadius),
+        child: Container(
+          padding: chipPaddingClosable,
+          color: getTagColor(tagEntity),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                tagEntity.tag,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontFamily: 'Oswald',
+                  color: AppColors.tagTextColor,
                 ),
-                onTap: onTap,
               ),
-            ),
-          ],
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 4.0),
+                    child: Icon(
+                      MdiIcons.close,
+                      size: 16,
+                      color: AppColors.tagTextColor,
+                    ),
+                  ),
+                  onTap: onTapRemove,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.8+562
+version: 0.6.9+563
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR improves tag management by allowing double tap on a tag chip to get to the tag definition directly, e.g. for changing a general tag to a story of person tag.