### PR TITLE
Make the measurables detail page scrollable again

### DIFF
--- a/lotti/lib/pages/settings/measurables/measurable_details_page.dart
+++ b/lotti/lib/pages/settings/measurables/measurable_details_page.dart
@@ -33,159 +33,166 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
   Widget build(BuildContext context) {
     final MeasurableDataType item = widget.dataType;
 
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(16),
-            child: Container(
-              color: AppColors.headerBgColor,
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                children: [
-                  FormBuilder(
-                    key: _formKey,
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    child: Column(
-                      children: <Widget>[
-                        FormTextField(
-                          initialValue: item.name,
-                          labelText: 'Name',
-                          name: 'name',
-                        ),
-                        FormTextField(
-                          initialValue: item.displayName,
-                          labelText: 'Display name',
-                          name: 'displayName',
-                        ),
-                        FormTextField(
-                          initialValue: item.description,
-                          labelText: 'Description',
-                          name: 'description',
-                        ),
-                        FormTextField(
-                          initialValue: item.unitName,
-                          labelText: 'Unit abbreviation',
-                          name: 'unitName',
-                        ),
-                        FormBuilderSwitch(
-                          name: 'private',
-                          initialValue: item.private,
-                          title: Text(
-                            'Private: ',
-                            style: formLabelStyle,
-                          ),
-                          activeColor: AppColors.private,
-                        ),
-                        FormBuilderSwitch(
-                          name: 'favorite',
-                          initialValue: item.favorite,
-                          title: Text(
-                            'Favorite: ',
-                            style: formLabelStyle,
-                          ),
-                          activeColor: AppColors.starredGold,
-                        ),
-                        FormBuilderDropdown(
-                          name: 'aggregationType',
-                          initialValue: item.aggregationType,
-                          decoration: InputDecoration(
-                            labelText: 'Aggregation Type:',
-                            labelStyle: labelStyle,
-                          ),
-                          style: const TextStyle(fontSize: 48),
-                          allowClear: true,
-                          dropdownColor: AppColors.headerBgColor,
-                          hint: Text(
-                            'Select aggregation type',
-                            style: formLabelStyle.copyWith(
-                              fontSize: 12,
+    return Expanded(
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Container(
+                  color: AppColors.headerBgColor,
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    children: [
+                      FormBuilder(
+                        key: _formKey,
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                        child: Column(
+                          children: <Widget>[
+                            FormTextField(
+                              initialValue: item.name,
+                              labelText: 'Name',
+                              name: 'name',
                             ),
-                          ),
-                          items: AggregationType.values.map((aggregationType) {
-                            return DropdownMenuItem(
-                              value: aggregationType,
-                              child: Padding(
-                                padding: const EdgeInsets.all(8.0),
+                            FormTextField(
+                              initialValue: item.displayName,
+                              labelText: 'Display name',
+                              name: 'displayName',
+                            ),
+                            FormTextField(
+                              initialValue: item.description,
+                              labelText: 'Description',
+                              name: 'description',
+                            ),
+                            FormTextField(
+                              initialValue: item.unitName,
+                              labelText: 'Unit abbreviation',
+                              name: 'unitName',
+                            ),
+                            FormBuilderSwitch(
+                              name: 'private',
+                              initialValue: item.private,
+                              title: Text(
+                                'Private: ',
+                                style: formLabelStyle,
+                              ),
+                              activeColor: AppColors.private,
+                            ),
+                            FormBuilderSwitch(
+                              name: 'favorite',
+                              initialValue: item.favorite,
+                              title: Text(
+                                'Favorite: ',
+                                style: formLabelStyle,
+                              ),
+                              activeColor: AppColors.starredGold,
+                            ),
+                            FormBuilderDropdown(
+                              name: 'aggregationType',
+                              initialValue: item.aggregationType,
+                              decoration: InputDecoration(
+                                labelText: 'Aggregation Type:',
+                                labelStyle: labelStyle,
+                              ),
+                              style: const TextStyle(fontSize: 48),
+                              allowClear: true,
+                              dropdownColor: AppColors.headerBgColor,
+                              hint: Text(
+                                'Select aggregation type',
+                                style: formLabelStyle.copyWith(
+                                  fontSize: 12,
+                                ),
+                              ),
+                              items:
+                                  AggregationType.values.map((aggregationType) {
+                                return DropdownMenuItem(
+                                  value: aggregationType,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(8.0),
+                                    child: Text(
+                                      '$aggregationType',
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        color: AppColors.entryTextColor,
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            TextButton(
+                              onPressed: () async {
+                                _formKey.currentState!.save();
+                                if (_formKey.currentState!.validate()) {
+                                  final formData = _formKey.currentState?.value;
+                                  debugPrint('$formData');
+                                  MeasurableDataType dataType = item.copyWith(
+                                    name: '${formData!['name']}'
+                                        .trim()
+                                        .replaceAll(' ', '_')
+                                        .toLowerCase(),
+                                    description:
+                                        '${formData['description']}'.trim(),
+                                    unitName: '${formData['unitName']}'.trim(),
+                                    displayName:
+                                        '${formData['displayName']}'.trim(),
+                                    private: formData['private'],
+                                    favorite: formData['favorite'],
+                                    aggregationType:
+                                        formData['aggregationType'],
+                                  );
+
+                                  persistenceLogic
+                                      .upsertEntityDefinition(dataType);
+                                  context.router.pop();
+                                }
+                              },
+                              child: const Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 24.0),
                                 child: Text(
-                                  '$aggregationType',
+                                  'Save',
                                   style: TextStyle(
-                                    fontSize: 16,
-                                    color: AppColors.entryTextColor,
+                                    fontSize: 20,
+                                    fontFamily: 'Oswald',
+                                    fontWeight: FontWeight.bold,
                                   ),
                                 ),
                               ),
-                            );
-                          }).toList(),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 16.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        TextButton(
-                          onPressed: () async {
-                            _formKey.currentState!.save();
-                            if (_formKey.currentState!.validate()) {
-                              final formData = _formKey.currentState?.value;
-                              debugPrint('$formData');
-                              MeasurableDataType dataType = item.copyWith(
-                                name: '${formData!['name']}'
-                                    .trim()
-                                    .replaceAll(' ', '_')
-                                    .toLowerCase(),
-                                description:
-                                    '${formData['description']}'.trim(),
-                                unitName: '${formData['unitName']}'.trim(),
-                                displayName:
-                                    '${formData['displayName']}'.trim(),
-                                private: formData['private'],
-                                favorite: formData['favorite'],
-                                aggregationType: formData['aggregationType'],
-                              );
-
-                              persistenceLogic.upsertEntityDefinition(dataType);
-                              context.router.pop();
-                            }
-                          },
-                          child: const Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 24.0),
-                            child: Text(
-                              'Save',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontFamily: 'Oswald',
-                                fontWeight: FontWeight.bold,
-                              ),
                             ),
-                          ),
+                            IconButton(
+                              icon: const Icon(MdiIcons.trashCanOutline),
+                              iconSize: 24,
+                              tooltip: 'Delete',
+                              color: AppColors.appBarFgColor,
+                              onPressed: () {
+                                persistenceLogic.upsertEntityDefinition(
+                                  item.copyWith(
+                                    deletedAt: DateTime.now(),
+                                  ),
+                                );
+                                context.router.pop();
+                              },
+                            ),
+                          ],
                         ),
-                        IconButton(
-                          icon: const Icon(MdiIcons.trashCanOutline),
-                          iconSize: 24,
-                          tooltip: 'Delete',
-                          color: AppColors.appBarFgColor,
-                          onPressed: () {
-                            persistenceLogic.upsertEntityDefinition(
-                              item.copyWith(
-                                deletedAt: DateTime.now(),
-                              ),
-                            );
-                            context.router.pop();
-                          },
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
-            ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.9+563
+version: 0.6.10+564
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes scroll on the measurables detail page, which broke when migrating to `auto_route`.