### PR TITLE
Change health import to sorted by day

### DIFF
--- a/lotti/lib/logic/health_import.dart
+++ b/lotti/lib/logic/health_import.dart
@@ -64,7 +64,10 @@ class HealthImport {
         'flutterHealthFit isAuthorized: $isAuthorized, isAnyAuth: $isAnyAuth');
 
     Future<void> addEntries(Map<DateTime, int> data, String type) async {
-      for (MapEntry<DateTime, int> dailyStepsEntry in data.entries) {
+      List<MapEntry<DateTime, int>> entries = List.from(data.entries);
+      entries.sort((a, b) => a.key.compareTo(b.key));
+
+      for (MapEntry<DateTime, int> dailyStepsEntry in entries) {
         DateTime dateFrom = dailyStepsEntry.key;
         DateTime dateTo = dateFrom
             .add(const Duration(days: 1))
@@ -122,7 +125,7 @@ class HealthImport {
           types,
         );
 
-        for (HealthDataPoint dataPoint in dataPoints) {
+        for (HealthDataPoint dataPoint in dataPoints.reversed) {
           DiscreteQuantityData discreteQuantity = DiscreteQuantityData(
             dateFrom: dataPoint.dateFrom,
             dateTo: dataPoint.dateTo,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.15+583
+version: 0.6.17+587
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes health imports to process data by day in ascending order so that a failure in the process would not interfere with subsequent delta fetches.