### PR TITLE
Measurement data migration

### DIFF
--- a/lotti/lib/classes/entity_definitions.dart
+++ b/lotti/lib/classes/entity_definitions.dart
@@ -86,6 +86,7 @@ class MeasurementData with _$MeasurementData {
     required DateTime dateTo,
     required num value,
     required MeasurableDataType dataType,
+    String? dataTypeId,
   }) = _MeasurementData;
 
   factory MeasurementData.fromJson(Map<String, dynamic> json) =>

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_links.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -595,10 +596,22 @@ class JournalDb extends _$JournalDb {
   }
 }
 
+Future<File> getDatabaseFile() async {
+  final dbFolder = await getApplicationDocumentsDirectory();
+  return File(p.join(dbFolder.path, 'db.sqlite'));
+}
+
+Future<void> createDbBackup() async {
+  final File file = await getDatabaseFile();
+  String ts = DateFormat('yyyy-MM-dd_HH-mm-ss-S').format(DateTime.now());
+  Directory backupDir =
+      await Directory('${file.parent.path}/backup').create(recursive: true);
+  await file.copy('${backupDir.path}/db.$ts.sqlite');
+}
+
 LazyDatabase _openConnection() {
   return LazyDatabase(() async {
-    final dbFolder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(dbFolder.path, 'db.sqlite'));
+    final File file = await getDatabaseFile();
     return NativeDatabase(file);
   });
 }

--- a/lotti/lib/database/maintenance.dart
+++ b/lotti/lib/database/maintenance.dart
@@ -56,6 +56,28 @@ class Maintenance {
     }
   }
 
+  Future<void> migrateMeasurableTypeIds() async {
+    final int count = await _db.getJournalCount();
+    const int pageSize = 100;
+    final int pages = (count / pageSize).ceil();
+
+    for (int page = 0; page <= pages; page++) {
+      List<JournalDbEntity> dbEntities =
+          await _db.orderedJournal(pageSize, page * pageSize).get();
+
+      List<JournalEntity> entries = entityStreamMapper(dbEntities);
+      for (JournalEntity entry in entries) {
+        if (entry is MeasurementEntry) {
+          var data = entry.data;
+          await persistenceLogic.updateJournalEntity(
+            entry.copyWith(data: data.copyWith(dataTypeId: data.dataType.id)),
+            entry.meta,
+          );
+        }
+      }
+    }
+  }
+
   Future<void> deleteTaggedLinks() async {
     await _db.deleteTagged();
   }

--- a/lotti/lib/database/maintenance.dart
+++ b/lotti/lib/database/maintenance.dart
@@ -69,10 +69,12 @@ class Maintenance {
       for (JournalEntity entry in entries) {
         if (entry is MeasurementEntry) {
           var data = entry.data;
-          await persistenceLogic.updateJournalEntity(
-            entry.copyWith(data: data.copyWith(dataTypeId: data.dataType.id)),
-            entry.meta,
-          );
+          if (data.dataTypeId == null) {
+            await persistenceLogic.updateJournalEntity(
+              entry.copyWith(data: data.copyWith(dataTypeId: data.dataType.id)),
+              entry.meta,
+            );
+          }
         }
       }
     }

--- a/lotti/lib/database/maintenance.dart
+++ b/lotti/lib/database/maintenance.dart
@@ -12,6 +12,8 @@ class Maintenance {
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
 
   Future<void> recreateTaggedLinks() async {
+    await createDbBackup();
+
     int count = await _db.getJournalCount();
     int pageSize = 100;
     int pages = (count / pageSize).ceil();
@@ -28,6 +30,8 @@ class Maintenance {
   }
 
   Future<void> recreateStoryAssignment() async {
+    await createDbBackup();
+
     final int count = await _db.getJournalCount();
     const int pageSize = 100;
     final int pages = (count / pageSize).ceil();
@@ -57,6 +61,8 @@ class Maintenance {
   }
 
   Future<void> migrateMeasurableTypeIds() async {
+    await createDbBackup();
+
     final int count = await _db.getJournalCount();
     const int pageSize = 100;
     final int pages = (count / pageSize).ceil();
@@ -81,6 +87,7 @@ class Maintenance {
   }
 
   Future<void> deleteTaggedLinks() async {
+    await createDbBackup();
     await _db.deleteTagged();
   }
 }

--- a/lotti/lib/pages/settings/maintenance_page.dart
+++ b/lotti/lib/pages/settings/maintenance_page.dart
@@ -54,6 +54,10 @@ class _MaintenancePageState extends State<MaintenancePage> {
                   title: 'Assign stories from parents',
                   onTap: () => _maintenance.recreateStoryAssignment(),
                 ),
+                MaintenanceCard(
+                  title: 'Migrate measurable type IDs',
+                  onTap: () => _maintenance.migrateMeasurableTypeIds(),
+                ),
               ],
             );
           },

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.18+588
+version: 0.6.18+589
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.18+589
+version: 0.6.18+590
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.17+587
+version: 0.6.18+588
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds a maintenance task for migrating measurements to have the data type ID assigned. In a subsequent step, the full data type can then be removed from measurement so that they are only stored in one place.