### PR TITLE
Change time charts to minutes instead of hours

### DIFF
--- a/lotti/lib/widgets/charts/dashboard_story_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_story_chart.dart
@@ -91,11 +91,10 @@ class _DashboardStoryChartState extends State<DashboardStoryChart> {
                     domainAxis: timeSeriesAxis,
                     defaultRenderer: defaultRenderer,
                     primaryMeasureAxis: const charts.NumericAxisSpec(
-                        tickProviderSpec: charts.BasicNumericTickProviderSpec(
-                          zeroBound: true,
-                        ),
-                        tickFormatterSpec:
-                            charts.BasicNumericTickFormatterSpec(hoursToHhMm)),
+                      tickProviderSpec: charts.BasicNumericTickProviderSpec(
+                        zeroBound: true,
+                      ),
+                    ),
                   ),
                   Positioned(
                     top: 0,

--- a/lotti/lib/widgets/charts/dashboard_story_data.dart
+++ b/lotti/lib/widgets/charts/dashboard_story_data.dart
@@ -9,7 +9,7 @@ List<Observation> aggregateStoryDailyTimeSum(
   required DateTime rangeStart,
   required DateTime rangeEnd,
 }) {
-  Map<String, num> hoursByDay = {};
+  Map<String, num> minutesByDay = {};
 
   Duration range = rangeEnd.difference(rangeStart);
   List<String> dayStrings = List<String>.generate(range.inDays, (days) {
@@ -18,21 +18,21 @@ List<Observation> aggregateStoryDailyTimeSum(
   });
 
   for (final dayString in dayStrings) {
-    hoursByDay[dayString] = 0;
+    minutesByDay[dayString] = 0;
   }
 
   for (final entity in entities) {
     String dayString = ymd(entity!.meta.dateFrom);
-    num n = hoursByDay[dayString] ?? 0;
+    num n = minutesByDay[dayString] ?? 0;
     num duration =
-        entity.meta.dateTo.difference(entity.meta.dateFrom).inSeconds / 3600;
-    hoursByDay[dayString] = n + duration;
+        entity.meta.dateTo.difference(entity.meta.dateFrom).inSeconds / 60;
+    minutesByDay[dayString] = n + duration;
   }
 
   List<Observation> aggregated = [];
-  for (final dayString in hoursByDay.keys) {
+  for (final dayString in minutesByDay.keys) {
     DateTime day = DateTime.parse(dayString);
-    aggregated.add(Observation(day, hoursByDay[dayString] ?? 0));
+    aggregated.add(Observation(day, minutesByDay[dayString] ?? 0));
   }
 
   return aggregated;

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -399,7 +399,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   delta_markdown:
     dependency: "direct main"
     description:
@@ -843,7 +843,7 @@ packages:
       name: form_builder_validators
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.7.0"
+    version: "7.8.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -1557,7 +1557,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -1989,7 +1989,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   window_manager:
     dependency: "direct main"
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.21+595
+version: 0.6.22+596
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes time charts to use minutes instead of hours, which improves the scaling of the vertical axis. Still needs more thought though, but it is an improvement.