### PR TITLE
Fix ordering measurables

### DIFF
--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -88,8 +88,14 @@ MeasurableDataType measurableDataType(MeasurableDbEntity dbEntity) {
 }
 
 List<MeasurableDataType> measurableDataTypeStreamMapper(
-    List<MeasurableDbEntity> dbEntities) {
-  return dbEntities.map((e) => measurableDataType(e)).toList();
+    List<MeasurableDbEntity> items) {
+  List<MeasurableDataType> res =
+      items.map((e) => measurableDataType(e)).toList();
+
+  res.sort((a, b) =>
+      a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase()));
+
+  return res;
 }
 
 MeasurableDbEntity measurableDbEntity(MeasurableDataType dataType) {

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -284,15 +284,13 @@ SELECT * FROM conflicts
 activeMeasurableTypes:
 SELECT * FROM measurable_types
   WHERE deleted = false
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
-  ORDER BY unique_name ASC;
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'));
 
 measurableTypeById:
 SELECT * FROM measurable_types
   WHERE deleted = false
   AND id = :id
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
-  ORDER BY unique_name ASC;
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'));
 
 measurementsByType:
 SELECT * FROM journal

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.23+597
+version: 0.6.24+598
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes the sort order for measurables after filling the unique name database column with the ID. Instead of sorting at database level, this can also happen in the mapper as there will be a limited number of measurables.