### PR TITLE
Fix creation of tagged entries from sync

### DIFF
--- a/lotti/lib/logic/persistence_logic.dart
+++ b/lotti/lib/logic/persistence_logic.dart
@@ -443,7 +443,10 @@ class PersistenceLogic {
 
       JournalEntity withTags = journalEntity.copyWith(
         meta: journalEntity.meta.copyWith(
-          tagIds: storyTags,
+          tagIds: <String>{
+            ...?journalEntity.meta.tagIds,
+            ...storyTags,
+          }.toList(),
         ),
       );
 

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.24+598
+version: 0.6.25+599
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes the creation of tags for entries from sync in the case that they had tags assigned from creation, as is the case when story tags are copied over from a linked entry.