### PR TITLE
Stop recording when pressing record again

### DIFF
--- a/lotti/lib/widgets/audio/audio_recorder.dart
+++ b/lotti/lib/widgets/audio/audio_recorder.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
@@ -53,7 +52,6 @@ class AudioRecorderWidget extends StatelessWidget {
                 color: AppColors.inactiveAudioControl,
                 onPressed: () {
                   context.read<AudioRecorderCubit>().stop();
-                  context.router.pop();
                 },
               ),
               Padding(

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.25+599
+version: 0.6.26+600
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes a crash where pressing record in the UI again and then stop would crash the app. Instead, pressing record again stops the recording now and returns the user to the journal view.