### PR TITLE
Add duplicate filter for db streams to ensure exactly once delivery

### DIFF
--- a/lotti/lib/database/stream_helpers.dart
+++ b/lotti/lib/database/stream_helpers.dart
@@ -1,0 +1,24 @@
+import 'package:collection/collection.dart';
+
+// This function returns a stateful stream filter
+// function that compares the previous event on
+// the stream with the latest, and filters those
+// that are found equal using deep collection
+// equality. This allows exactly once deliver on
+// a stream instead of at least once previously,
+// which lead to plenty of costly re-renders.
+bool Function(T next) makeDuplicateFilter<T>() {
+  Function deepEq = const DeepCollectionEquality().equals;
+  T? prev;
+
+  bool duplicateFilter(T next) {
+    if (deepEq(prev, next)) {
+      return false;
+    } else {
+      prev = next;
+      return true;
+    }
+  }
+
+  return duplicateFilter;
+}

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.31+605
+version: 0.6.32+606
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR add a stateful stream filter function that compares the previous event on the stream with the latest, and filters those that are found equal using deep collection equality. This allows exactly once deliver on a stream instead of at least once previously, which lead to plenty of costly re-renders.
