### PR TITLE
Improve dashboard charts: zeroBound only where it makes sense

### DIFF
--- a/lotti/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_health_chart.dart
@@ -68,7 +68,9 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
     HealthTypeConfig? healthType = healthTypes[dataType];
     charts.SeriesRendererConfig<DateTime>? defaultRenderer;
 
-    if (healthType?.chartType == HealthChartType.barChart) {
+    final bool isBarChart = healthType?.chartType == HealthChartType.barChart;
+
+    if (isBarChart) {
       defaultRenderer = charts.BarRendererConfig<DateTime>();
     } else {
       defaultRenderer = charts.LineRendererConfig<DateTime>(
@@ -145,11 +147,10 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
                         ),
                       ],
                       primaryMeasureAxis: charts.NumericAxisSpec(
-                        tickProviderSpec:
-                            const charts.BasicNumericTickProviderSpec(
-                          zeroBound: false,
+                        tickProviderSpec: charts.BasicNumericTickProviderSpec(
+                          zeroBound: isBarChart,
                           desiredTickCount: 5,
-                          dataIsInWholeNumbers: true,
+                          dataIsInWholeNumbers: false,
                         ),
                         tickFormatterSpec:
                             healthType != null && healthType.hoursMinutes

--- a/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -68,7 +68,10 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
 
               charts.SeriesRendererConfig<DateTime>? defaultRenderer;
 
-              if (measurableDataType.aggregationType == AggregationType.none) {
+              final bool aggregationNone =
+                  measurableDataType.aggregationType == AggregationType.none;
+
+              if (aggregationNone) {
                 defaultRenderer = charts.LineRendererConfig<DateTime>(
                   includePoints: false,
                   strokeWidthPx: 2,
@@ -153,6 +156,14 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
                                   widget.rangeStart, widget.rangeEnd)
                             ],
                             domainAxis: timeSeriesAxis,
+                            primaryMeasureAxis: charts.NumericAxisSpec(
+                              tickProviderSpec:
+                                  charts.BasicNumericTickProviderSpec(
+                                zeroBound: !aggregationNone,
+                                dataIsInWholeNumbers: true,
+                                desiredTickCount: 4,
+                              ),
+                            ),
                           ),
                           MeasurablesChartInfoWidget(measurableDataType),
                         ],

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.32+606
+version: 0.6.33+607
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR improves the data display in dashboards so zero bound display is only used where it makes sense.