### PR TITLE
Add localizations in iOS and macOS Info.plist files

### DIFF
--- a/lotti/ios/Runner/Info.plist
+++ b/lotti/ios/Runner/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+        <key>CFBundleLocalizations</key>
+        <array>
+            <string>en</string>
+            <string>de</string>
+            <string>fr</string>
+        </array>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleExecutable</key>

--- a/lotti/macos/Runner/Info.plist
+++ b/lotti/macos/Runner/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>de</string>
+		<string>fr</string>
+    </array>
 	<key>NSLocationUsageDescription</key>
 	<string>Obtain location for journal entries</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.41+631
+version: 0.6.42+632
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds the supported localizations in both `ios/Info.plist` and `macos/Info.plist`.