### PR TITLE
Entry timeline

### DIFF
--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -83,6 +83,13 @@ List<JournalEntity> entityStreamMapper(List<JournalDbEntity> dbEntities) {
   return dbEntities.map((e) => fromDbEntity(e)).toList();
 }
 
+List<JournalEntity> nullAwareEntityStreamMapper(
+    List<JournalDbEntity?> dbEntities) {
+  return entityStreamMapper(
+    dbEntities.whereType<JournalDbEntity>().toList(),
+  );
+}
+
 MeasurableDataType measurableDataType(MeasurableDbEntity dbEntity) {
   return MeasurableDataType.fromJson(json.decode(dbEntity.serialized));
 }

--- a/lotti/lib/database/conversions.dart
+++ b/lotti/lib/database/conversions.dart
@@ -80,7 +80,11 @@ JournalEntity fromDbEntity(JournalDbEntity dbEntity) {
 }
 
 List<JournalEntity> entityStreamMapper(List<JournalDbEntity> dbEntities) {
-  return dbEntities.map((e) => fromDbEntity(e)).toList();
+  return dbEntities.map((dbEntity) => fromDbEntity(dbEntity)).toList();
+}
+
+List<String> entityIdStreamMapper(List<JournalDbEntity> dbEntities) {
+  return dbEntities.map((dbEntity) => dbEntity.id).toList();
 }
 
 List<JournalEntity> nullAwareEntityStreamMapper(

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -326,11 +326,11 @@ class JournalDb extends _$JournalDb {
         .map(entityStreamMapper);
   }
 
-  Stream<List<JournalEntity>> watchJournalEntitiesByIds(List<String> ids) {
-    return journalEntitiesByIds(ids)
+  Stream<List<String>> watchSortedLinkedEntityIds(List<String> linkedIds) {
+    return journalEntitiesByIds(linkedIds)
         .watch()
-        .where(makeDuplicateFilter())
-        .map(entityStreamMapper);
+        .map(entityIdStreamMapper)
+        .where(makeDuplicateFilter());
   }
 
   Stream<List<String>> watchLinkedEntityIds(String linkedFrom) {

--- a/lotti/lib/database/database.dart
+++ b/lotti/lib/database/database.dart
@@ -326,6 +326,19 @@ class JournalDb extends _$JournalDb {
         .map(entityStreamMapper);
   }
 
+  Stream<List<JournalEntity>> watchJournalEntitiesByIds(List<String> ids) {
+    return journalEntitiesByIds(ids)
+        .watch()
+        .where(makeDuplicateFilter())
+        .map(entityStreamMapper);
+  }
+
+  Stream<List<String>> watchLinkedEntityIds(String linkedFrom) {
+    return linkedJournalEntityIds(linkedFrom)
+        .watch()
+        .where(makeDuplicateFilter());
+  }
+
   Future<List<JournalEntity>> getLinkedEntities(String linkedFrom) async {
     var dbEntities = await linkedJournalEntities(linkedFrom).get();
     return dbEntities.map(fromDbEntity).toList();

--- a/lotti/lib/database/database.drift
+++ b/lotti/lib/database/database.drift
@@ -417,6 +417,16 @@ SELECT * FROM journal
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
+journalEntitiesByIds:
+SELECT * FROM journal
+  WHERE deleted = false
+  AND id IN :ids
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  ORDER BY date_from DESC;
+
+linkedJournalEntityIds:
+SELECT to_id FROM linked_entries WHERE from_id = :from_id;
+
 linkedToJournalEntities:
 SELECT * FROM journal
   WHERE deleted = false

--- a/lotti/lib/database/editor_db.dart
+++ b/lotti/lib/database/editor_db.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'editor_db.g.dart';
+
+@DriftDatabase(
+  include: {'editor_db.drift'},
+)
+class EditorDb extends _$EditorDb {
+  EditorDb() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, 'editor_db.sqlite'));
+    return NativeDatabase(file);
+  });
+}

--- a/lotti/lib/database/editor_db.drift
+++ b/lotti/lib/database/editor_db.drift
@@ -1,0 +1,27 @@
+CREATE TABLE editor_state (
+  entry_id TEXT NOT NULL,
+  latest_vc_version INTEGER NOT NULL,
+  created_at DATETIME NOT NULL,
+  delta TEXT NOT NULL,
+  PRIMARY KEY (entry_id)
+);
+
+CREATE INDEX idx_composite_version
+ON editor_state (entry_id, latest_vc_version DESC, created_at DESC);
+
+CREATE INDEX idx_created_at
+ON editor_state (created_at DESC);
+
+CREATE INDEX idx_latest_vc_version
+ON editor_state (latest_vc_version DESC);
+
+CREATE INDEX idx_entry_id
+ON editor_state (entry_id);
+
+/* Queries ----------------------------------------------------- */
+latestEditorState:
+SELECT * FROM editor_state
+  WHERE entry_id = :entry_id
+  AND latest_vc_version = :latest_vc_version
+  ORDER BY created_at DESC
+  LIMIT :limit;

--- a/lotti/lib/get_it.dart
+++ b/lotti/lib/get_it.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/sync_config_service.dart';
@@ -33,6 +34,7 @@ void registerSingletons() {
   getIt.registerSingleton<SyncInboxService>(SyncInboxService());
   getIt.registerSingleton<LinkService>(LinkService());
   getIt.registerSingleton<NotificationService>(NotificationService());
+  getIt.registerSingleton<EditorStateService>(EditorStateService());
   getIt.registerSingleton<Maintenance>(Maintenance());
   getIt.registerSingleton<AppRouter>(AppRouter());
 }

--- a/lotti/lib/pages/journal/entry_details_page.dart
+++ b/lotti/lib/pages/journal/entry_details_page.dart
@@ -76,11 +76,11 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
-                  LinkedFromEntriesWidget(item: item),
                   EntryDetailWidget(
                     entryId: widget.entryId,
                   ),
                   LinkedEntriesWidget(item: item),
+                  LinkedFromEntriesWidget(item: item),
                 ],
               ),
             ),

--- a/lotti/lib/pages/journal/entry_details_page.dart
+++ b/lotti/lib/pages/journal/entry_details_page.dart
@@ -30,7 +30,6 @@ class EntryDetailPage extends StatefulWidget {
 
 class _EntryDetailPageState extends State<EntryDetailPage> {
   final JournalDb _db = getIt<JournalDb>();
-  final FocusNode _focusNode = FocusNode();
   bool showDetails = false;
 
   late final Stream<JournalEntity?> _stream =

--- a/lotti/lib/pages/journal/entry_details_page.dart
+++ b/lotti/lib/pages/journal/entry_details_page.dart
@@ -3,31 +3,15 @@ import 'dart:io';
 import 'package:auto_route/annotations.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_form_builder/flutter_form_builder.dart';
-import 'package:flutter_quill/flutter_quill.dart' hide Text;
-import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/theme.dart';
 import 'package:lotti/utils/platform.dart';
-import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/create/add_actions.dart';
-import 'package:lotti/widgets/journal/editor_tools.dart';
-import 'package:lotti/widgets/journal/editor_widget.dart';
-import 'package:lotti/widgets/journal/entry_detail_footer.dart';
 import 'package:lotti/widgets/journal/entry_detail_linked.dart';
 import 'package:lotti/widgets/journal/entry_detail_linked_from.dart';
-import 'package:lotti/widgets/journal/entry_image_widget.dart';
-import 'package:lotti/widgets/journal/entry_tools.dart';
-import 'package:lotti/widgets/journal/helpers.dart';
-import 'package:lotti/widgets/journal/tags_widget.dart';
-import 'package:lotti/widgets/misc/survey_summary.dart';
-import 'package:lotti/widgets/tasks/task_form.dart';
+import 'package:lotti/widgets/journal/entry_details_widget.dart';
 import 'package:path_provider/path_provider.dart';
 
 class EntryDetailPage extends StatefulWidget {
@@ -83,28 +67,6 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
           return const SizedBox.shrink();
         }
 
-        EntryText? entryText = item.map(
-          journalEntry: (item) => item.entryText,
-          journalImage: (item) => item.entryText,
-          journalAudio: (item) => item.entryText,
-          task: (item) => item.entryText,
-          quantitative: (_) => null,
-          measurement: (item) => item.entryText,
-          workout: (item) => item.entryText,
-          habitCompletion: (item) => item.entryText,
-          survey: (_) => null,
-        );
-
-        QuillController _controller =
-            makeController(serializedQuill: entryText?.quill);
-
-        void saveText() {
-          EntryText entryText = entryTextFromController(_controller);
-          HapticFeedback.heavyImpact();
-
-          persistenceLogic.updateJournalEntityText(item.meta.id, entryText);
-        }
-
         return Stack(
           children: [
             SingleChildScrollView(
@@ -115,182 +77,8 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
                   LinkedFromEntriesWidget(item: item),
-                  Container(
-                    margin: const EdgeInsets.symmetric(
-                      horizontal: 12.0,
-                      vertical: 4.0,
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8.0),
-                      child: Container(
-                        color: AppColors.headerBgColor,
-                        child: Column(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: TagsWidget(item: item),
-                            ),
-                            item.map(
-                              journalAudio: (JournalAudio audio) {
-                                return Column(
-                                  children: [
-                                    const AudioPlayerWidget(),
-                                    EditorWidget(
-                                      controller: _controller,
-                                      journalEntity: item,
-                                      focusNode: _focusNode,
-                                      saveFn: saveText,
-                                    ),
-                                  ],
-                                );
-                              },
-                              journalImage: (JournalImage image) {
-                                return Column(
-                                  children: [
-                                    Container(
-                                      width: MediaQuery.of(context).size.width,
-                                      color: Colors.black,
-                                      child: EntryImageWidget(
-                                        focusNode: _focusNode,
-                                        journalImage: image,
-                                      ),
-                                    ),
-                                    EditorWidget(
-                                      controller: _controller,
-                                      focusNode: _focusNode,
-                                      readOnly: widget.readOnly,
-                                      journalEntity: item,
-                                      saveFn: saveText,
-                                    ),
-                                  ],
-                                );
-                              },
-                              journalEntry: (JournalEntry journalEntry) {
-                                return EditorWidget(
-                                  controller: _controller,
-                                  focusNode: _focusNode,
-                                  readOnly: widget.readOnly,
-                                  saveFn: saveText,
-                                  journalEntity: item,
-                                );
-                              },
-                              measurement: (MeasurementEntry entry) {
-                                return EditorWidget(
-                                  controller: _controller,
-                                  focusNode: _focusNode,
-                                  readOnly: widget.readOnly,
-                                  saveFn: saveText,
-                                  journalEntity: item,
-                                );
-                              },
-                              workout: (WorkoutEntry workout) {
-                                WorkoutData data = workout.data;
-                                return Column(
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.all(8.0),
-                                      child: EntryTextWidget(data.toString()),
-                                    ),
-                                    EditorWidget(
-                                      controller: _controller,
-                                      focusNode: _focusNode,
-                                      readOnly: widget.readOnly,
-                                      saveFn: saveText,
-                                      journalEntity: item,
-                                    ),
-                                  ],
-                                );
-                              },
-                              survey: (SurveyEntry surveyEntry) =>
-                                  SurveySummaryWidget(surveyEntry),
-                              quantitative: (qe) => qe.data.map(
-                                cumulativeQuantityData: (qd) => Padding(
-                                  padding: const EdgeInsets.all(24.0),
-                                  child: InfoText(
-                                    'End: ${df.format(qe.meta.dateTo)}'
-                                    '\n${formatType(qd.dataType)}: '
-                                    '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
-                                  ),
-                                ),
-                                discreteQuantityData: (qd) => Padding(
-                                  padding: const EdgeInsets.all(24.0),
-                                  child: InfoText(
-                                    'End: ${df.format(qe.meta.dateTo)}'
-                                    '\n${formatType(qd.dataType)}: '
-                                    '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
-                                  ),
-                                ),
-                              ),
-                              task: (Task task) {
-                                final formKey = GlobalKey<FormBuilderState>();
-
-                                void saveText() {
-                                  formKey.currentState?.save();
-                                  final formData = formKey.currentState?.value;
-                                  if (formData == null) {
-                                    persistenceLogic.updateTask(
-                                      entryText:
-                                          entryTextFromController(_controller),
-                                      journalEntityId: task.meta.id,
-                                      taskData: task.data,
-                                    );
-                                    HapticFeedback.heavyImpact();
-
-                                    return;
-                                  }
-                                  final DateTime due = formData['due'];
-                                  final String title = formData['title'];
-                                  final DateTime dt = formData['estimate'];
-                                  final String status = formData['status'];
-
-                                  final Duration estimate = Duration(
-                                    hours: dt.hour,
-                                    minutes: dt.minute,
-                                  );
-
-                                  HapticFeedback.heavyImpact();
-
-                                  TaskData updatedData = task.data.copyWith(
-                                    title: title,
-                                    estimate: estimate,
-                                    due: due,
-                                    status: taskStatusFromString(status),
-                                  );
-
-                                  persistenceLogic.updateTask(
-                                    entryText:
-                                        entryTextFromController(_controller),
-                                    journalEntityId: task.meta.id,
-                                    taskData: updatedData,
-                                  );
-                                }
-
-                                return TaskForm(
-                                  controller: _controller,
-                                  focusNode: _focusNode,
-                                  saveFn: saveText,
-                                  formKey: formKey,
-                                  data: task.data,
-                                  task: task,
-                                );
-                              },
-                              habitCompletion: (HabitCompletionEntry value) {
-                                return const SizedBox.shrink();
-                              },
-                            ),
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 8.0),
-                              child: EntryInfoRow(entityId: item.meta.id),
-                            ),
-                            EntryDetailFooter(
-                              item: item,
-                              saveFn: saveText,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
+                  EntryDetailWidget(
+                    entryId: widget.entryId,
                   ),
                   LinkedEntriesWidget(item: item),
                 ],

--- a/lotti/lib/pages/journal/entry_details_page.dart
+++ b/lotti/lib/pages/journal/entry_details_page.dart
@@ -78,6 +78,7 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
                 children: <Widget>[
                   EntryDetailWidget(
                     entryId: widget.entryId,
+                    popOnDelete: true,
                   ),
                   LinkedEntriesWidget(item: item),
                   LinkedFromEntriesWidget(item: item),

--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:lotti/classes/journal_entities.dart';
+
+class EditorStateService {
+  late final StreamController<JournalEntity?> _controller;
+
+  EditorStateService() {
+    _controller = StreamController<JournalEntity?>.broadcast();
+  }
+
+  Stream<JournalEntity?> getStream() {
+    return _controller.stream;
+  }
+
+  void saveTempState(String id, Delta delta) {
+    debugPrint('saveTempState $id $delta');
+  }
+}

--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -1,11 +1,18 @@
 import 'dart:async';
 
+import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/widgets/journal/editor_tools.dart';
 
 class EditorStateService {
   late final StreamController<JournalEntity?> _controller;
+  final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
 
   EditorStateService() {
     _controller = StreamController<JournalEntity?>.broadcast();
@@ -15,7 +22,24 @@ class EditorStateService {
     return _controller.stream;
   }
 
-  void saveTempState(String id, Delta delta) {
-    debugPrint('saveTempState $id $delta');
+  void saveTempState(String id, QuillController controller) {
+    Delta delta = deltaFromController(controller);
+    String json = quillJsonFromDelta(delta);
+    debugPrint('saveTempState not debounced $id');
+
+    EasyDebounce.debounce(
+      'tempSaveDelta-$id',
+      const Duration(seconds: 2),
+      () {
+        debugPrint('saveTempState debounced $id $json');
+      },
+    );
+  }
+
+  void saveState(String id, QuillController controller) async {
+    EntryText entryText = entryTextFromController(controller);
+    debugPrint('saveState $id ${entryText.toJson()}');
+    await _persistenceLogic.updateJournalEntityText(id, entryText);
+    HapticFeedback.heavyImpact();
   }
 }

--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/foundation.dart';
@@ -22,6 +23,13 @@ class EditorStateService {
 
   Stream<JournalEntity?> getStream() {
     return _streamController.stream;
+  }
+
+  Stream<bool> getPeriodicRandomStream(String? id) async* {
+    final rng = Random();
+    yield* Stream.periodic(const Duration(seconds: 5), (_) {
+      return rng.nextBool();
+    });
   }
 
   void saveTempState(String id, QuillController controller) {

--- a/lotti/lib/widgets/journal/editor_toolbar.dart
+++ b/lotti/lib/widgets/journal/editor_toolbar.dart
@@ -7,27 +7,22 @@ import 'package:lotti/services/link_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class ToolbarWidget extends StatelessWidget {
-  final LinkService _linkService = getIt<LinkService>();
-  final JournalEntity? _journalEntity;
+  final LinkService linkService = getIt<LinkService>();
+  final JournalEntity? journalEntity;
+  final QuillController controller;
+  final double toolbarIconSize;
+  final Function saveFn;
+  final WrapAlignment toolbarIconAlignment = WrapAlignment.start;
+  final QuillIconTheme? iconTheme;
 
   ToolbarWidget({
     Key? key,
-    required QuillController controller,
-    JournalEntity? journalEntity,
-    double toolbarIconSize = 24.0,
-    required Function saveFn,
+    required this.controller,
+    this.journalEntity,
+    required this.saveFn,
+    this.toolbarIconSize = 24.0,
     this.iconTheme,
-  })  : _controller = controller,
-        _saveFn = saveFn,
-        _journalEntity = journalEntity,
-        _toolbarIconSize = toolbarIconSize,
-        super(key: key);
-
-  final QuillController _controller;
-  final double _toolbarIconSize;
-  final Function _saveFn;
-  final WrapAlignment toolbarIconAlignment = WrapAlignment.start;
-  final QuillIconTheme? iconTheme;
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -35,90 +30,90 @@ class ToolbarWidget extends StatelessWidget {
 
     return QuillToolbar(
       key: key,
-      toolbarHeight: _toolbarIconSize * 2,
+      toolbarHeight: toolbarIconSize * 2,
       toolbarSectionSpacing: 4,
       toolbarIconAlignment: toolbarIconAlignment,
       multiRowsDisplay: true,
       children: [
         IconButton(
           icon: const Icon(Icons.save),
-          iconSize: _toolbarIconSize,
+          iconSize: toolbarIconSize,
           tooltip: localizations.journalToolbarSaveHint,
-          onPressed: () => _saveFn(),
+          onPressed: () => saveFn(),
         ),
         ToggleStyleButton(
           attribute: Attribute.bold,
           icon: Icons.format_bold,
-          iconSize: _toolbarIconSize,
-          controller: _controller,
+          iconSize: toolbarIconSize,
+          controller: controller,
           iconTheme: iconTheme,
         ),
         ToggleStyleButton(
           attribute: Attribute.italic,
           icon: Icons.format_italic,
-          iconSize: _toolbarIconSize,
-          controller: _controller,
+          iconSize: toolbarIconSize,
+          controller: controller,
           iconTheme: iconTheme,
         ),
         ToggleStyleButton(
           attribute: Attribute.underline,
           icon: Icons.format_underline,
-          iconSize: _toolbarIconSize,
-          controller: _controller,
+          iconSize: toolbarIconSize,
+          controller: controller,
           iconTheme: iconTheme,
         ),
         // TODO: bring back when supported by delta_markdown
         // ToggleStyleButton(
         //   attribute: Attribute.inlineCode,
         //   icon: Icons.code,
-        //   iconSize: _toolbarIconSize,
-        //   controller: _controller,
+        //   iconSize: toolbarIconSize,
+        //   controller: controller,
         //   iconTheme: iconTheme,
         // ),
         SelectHeaderStyleButton(
-          controller: _controller,
-          iconSize: _toolbarIconSize,
+          controller: controller,
+          iconSize: toolbarIconSize,
           iconTheme: iconTheme,
         ),
         ToggleStyleButton(
           attribute: Attribute.ul,
-          controller: _controller,
+          controller: controller,
           icon: Icons.format_list_bulleted,
-          iconSize: _toolbarIconSize,
+          iconSize: toolbarIconSize,
           iconTheme: iconTheme,
         ),
         ToggleStyleButton(
           attribute: Attribute.ol,
-          controller: _controller,
+          controller: controller,
           icon: Icons.format_list_numbered,
-          iconSize: _toolbarIconSize,
+          iconSize: toolbarIconSize,
           iconTheme: iconTheme,
         ),
         ToggleStyleButton(
           attribute: Attribute.codeBlock,
-          controller: _controller,
+          controller: controller,
           icon: Icons.code,
-          iconSize: _toolbarIconSize,
+          iconSize: toolbarIconSize,
           iconTheme: iconTheme,
         ),
-        if (_journalEntity != null)
+        if (journalEntity != null)
           IconButton(
             icon: const Icon(Icons.add_link),
-            iconSize: _toolbarIconSize,
+            iconSize: toolbarIconSize,
             tooltip: localizations.journalLinkFromHint,
-            onPressed: () => _linkService.linkFrom(_journalEntity!.meta.id),
+            onPressed: () => linkService.linkFrom(journalEntity!.meta.id),
           ),
-        if (_journalEntity != null)
+        if (journalEntity != null)
           IconButton(
             icon: const Icon(MdiIcons.target),
-            iconSize: _toolbarIconSize,
+            iconSize: toolbarIconSize,
             tooltip: localizations.journalLinkToHint,
-            onPressed: () => _linkService.linkTo(_journalEntity!.meta.id),
+            onPressed: () => linkService.linkTo(journalEntity!.meta.id),
           ),
         ClearFormatButton(
           icon: Icons.format_clear,
-          iconSize: _toolbarIconSize,
-          controller: _controller,
+          iconSize: toolbarIconSize,
+          controller: controller,
           iconTheme: iconTheme,
         ),
       ],

--- a/lotti/lib/widgets/journal/editor_toolbar.dart
+++ b/lotti/lib/widgets/journal/editor_toolbar.dart
@@ -3,7 +3,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/link_service.dart';
+import 'package:lotti/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class ToolbarWidget extends StatelessWidget {
@@ -11,15 +13,17 @@ class ToolbarWidget extends StatelessWidget {
   final JournalEntity? journalEntity;
   final QuillController controller;
   final double toolbarIconSize;
+  final String? id;
   final Function saveFn;
   final WrapAlignment toolbarIconAlignment = WrapAlignment.start;
   final QuillIconTheme? iconTheme;
 
   ToolbarWidget({
     Key? key,
+    required this.id,
     required this.controller,
-    this.journalEntity,
     required this.saveFn,
+    this.journalEntity,
     this.toolbarIconSize = 24.0,
     this.iconTheme,
   }) : super(key: key);
@@ -35,11 +39,11 @@ class ToolbarWidget extends StatelessWidget {
       toolbarIconAlignment: toolbarIconAlignment,
       multiRowsDisplay: true,
       children: [
-        IconButton(
-          icon: const Icon(Icons.save),
-          iconSize: toolbarIconSize,
-          tooltip: localizations.journalToolbarSaveHint,
-          onPressed: () => saveFn(),
+        SaveButton(
+          id: id,
+          toolbarIconSize: toolbarIconSize,
+          localizations: localizations,
+          saveFn: saveFn,
         ),
         ToggleStyleButton(
           attribute: Attribute.bold,
@@ -118,5 +122,38 @@ class ToolbarWidget extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class SaveButton extends StatelessWidget {
+  final EditorStateService editorStateService = getIt<EditorStateService>();
+
+  SaveButton({
+    Key? key,
+    required this.id,
+    required this.toolbarIconSize,
+    required this.localizations,
+    required this.saveFn,
+  }) : super(key: key);
+
+  final String? id;
+  final double toolbarIconSize;
+  final AppLocalizations localizations;
+  final Function saveFn;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+        stream: editorStateService.getPeriodicRandomStream(id),
+        builder: (context, snapshot) {
+          bool unsaved = snapshot.data ?? false;
+          return IconButton(
+            icon: const Icon(Icons.save),
+            color: unsaved ? AppColors.error : Colors.black,
+            iconSize: toolbarIconSize,
+            tooltip: localizations.journalToolbarSaveHint,
+            onPressed: () => saveFn(),
+          );
+        });
   }
 }

--- a/lotti/lib/widgets/journal/editor_toolbar.dart
+++ b/lotti/lib/widgets/journal/editor_toolbar.dart
@@ -144,7 +144,7 @@ class SaveButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
-        stream: editorStateService.getPeriodicRandomStream(id),
+        stream: editorStateService.getUnsavedStream(id),
         builder: (context, snapshot) {
           bool unsaved = snapshot.data ?? false;
           return IconButton(

--- a/lotti/lib/widgets/journal/editor_tools.dart
+++ b/lotti/lib/widgets/journal/editor_tools.dart
@@ -5,8 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/classes/entry_text.dart';
 
+Delta deltaFromController(QuillController controller) {
+  return controller.document.toDelta();
+}
+
 EntryText entryTextFromController(QuillController controller) {
-  Delta delta = controller.document.toDelta();
+  Delta delta = deltaFromController(controller);
   String json = jsonEncode(delta.toJson());
   String markdown = deltaToMarkdown(json);
 

--- a/lotti/lib/widgets/journal/editor_tools.dart
+++ b/lotti/lib/widgets/journal/editor_tools.dart
@@ -9,9 +9,13 @@ Delta deltaFromController(QuillController controller) {
   return controller.document.toDelta();
 }
 
+String quillJsonFromDelta(Delta delta) {
+  return jsonEncode(delta.toJson());
+}
+
 EntryText entryTextFromController(QuillController controller) {
   Delta delta = deltaFromController(controller);
-  String json = jsonEncode(delta.toJson());
+  String json = quillJsonFromDelta(delta);
   String markdown = deltaToMarkdown(json);
 
   return EntryText(

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -1,14 +1,19 @@
+import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/editor_styles.dart';
 import 'package:lotti/widgets/journal/editor_toolbar.dart';
+import 'package:lotti/widgets/journal/editor_tools.dart';
 
 class EditorWidget extends StatelessWidget {
+  final EditorStateService _editorStateService = getIt<EditorStateService>();
   final JournalEntity? _journalEntity;
 
-  const EditorWidget({
+  EditorWidget({
     Key? key,
     required QuillController controller,
     JournalEntity? journalEntity,
@@ -59,6 +64,19 @@ class EditorWidget extends StatelessWidget {
     }
   }
 
+  void tempSaveDelta(RawKeyEvent event) {
+    String id = _journalEntity?.meta.id ?? 'none';
+
+    EasyDebounce.debounce(
+      'tempSaveDelta-$id',
+      const Duration(seconds: 2),
+      () {
+        Delta delta = deltaFromController(_controller);
+        _editorStateService.saveTempState(id, delta);
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return RawKeyboardListener(
@@ -67,6 +85,7 @@ class EditorWidget extends StatelessWidget {
         keyFormatter(event, 'b', Attribute.bold);
         keyFormatter(event, 'i', Attribute.italic);
         saveViaKeyboard(event);
+        tempSaveDelta(event);
       },
       child: Container(
         color: AppColors.editorBgColor,

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -1,4 +1,3 @@
-import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/classes/journal_entities.dart';
@@ -7,7 +6,6 @@ import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/editor_styles.dart';
 import 'package:lotti/widgets/journal/editor_toolbar.dart';
-import 'package:lotti/widgets/journal/editor_tools.dart';
 
 class EditorWidget extends StatelessWidget {
   final EditorStateService _editorStateService = getIt<EditorStateService>();
@@ -56,15 +54,7 @@ class EditorWidget extends StatelessWidget {
 
   void tempSaveDelta(RawKeyEvent event) {
     String id = journalEntity?.meta.id ?? 'none';
-
-    EasyDebounce.debounce(
-      'tempSaveDelta-$id',
-      const Duration(seconds: 2),
-      () {
-        Delta delta = deltaFromController(controller);
-        _editorStateService.saveTempState(id, delta);
-      },
-    );
+    _editorStateService.saveTempState(id, controller);
   }
 
   @override

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -52,11 +52,6 @@ class EditorWidget extends StatelessWidget {
     }
   }
 
-  void tempSaveDelta(RawKeyEvent event) {
-    String id = journalEntity?.meta.id ?? 'none';
-    _editorStateService.saveTempState(id, controller);
-  }
-
   @override
   Widget build(BuildContext context) {
     return RawKeyboardListener(
@@ -65,7 +60,6 @@ class EditorWidget extends StatelessWidget {
         keyFormatter(event, 'b', Attribute.bold);
         keyFormatter(event, 'i', Attribute.italic);
         saveViaKeyboard(event);
-        tempSaveDelta(event);
       },
       child: Container(
         color: AppColors.editorBgColor,

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -68,6 +68,7 @@ class EditorWidget extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               ToolbarWidget(
+                id: journalEntity?.meta.id,
                 controller: controller,
                 saveFn: saveFn,
                 journalEntity: journalEntity,

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -11,67 +11,57 @@ import 'package:lotti/widgets/journal/editor_tools.dart';
 
 class EditorWidget extends StatelessWidget {
   final EditorStateService _editorStateService = getIt<EditorStateService>();
-  final JournalEntity? _journalEntity;
+  final JournalEntity? journalEntity;
+  final QuillController controller;
+  final double maxHeight;
+  final double minHeight;
+  final bool readOnly;
+  final bool autoFocus;
+  final double padding;
+  final Function saveFn;
+  final FocusNode focusNode;
 
   EditorWidget({
     Key? key,
-    required QuillController controller,
-    JournalEntity? journalEntity,
-    double minHeight = 80,
-    double maxHeight = double.maxFinite,
-    double padding = 16.0,
-    bool readOnly = false,
-    bool autoFocus = true,
-    required Function saveFn,
-    required FocusNode focusNode,
-  })  : _controller = controller,
-        _maxHeight = maxHeight,
-        _minHeight = minHeight,
-        _readOnly = readOnly,
-        _journalEntity = journalEntity,
-        _padding = padding,
-        _saveFn = saveFn,
-        _focusNode = focusNode,
-        _autoFocus = autoFocus,
-        super(key: key);
-
-  final QuillController _controller;
-  final double _maxHeight;
-  final double _minHeight;
-  final bool _readOnly;
-  final bool _autoFocus;
-  final double _padding;
-  final Function _saveFn;
-  final FocusNode _focusNode;
+    required this.controller,
+    this.journalEntity,
+    this.minHeight = 80,
+    this.maxHeight = double.maxFinite,
+    this.padding = 16.0,
+    this.readOnly = false,
+    this.autoFocus = true,
+    required this.saveFn,
+    required this.focusNode,
+  }) : super(key: key);
 
   void keyFormatter(RawKeyEvent event, String char, Attribute attribute) {
     if (event.data.isMetaPressed && event.character == char) {
-      if (_controller
+      if (controller
           .getSelectionStyle()
           .attributes
           .keys
           .contains(attribute.key)) {
-        _controller.formatSelection(Attribute.clone(attribute, null));
+        controller.formatSelection(Attribute.clone(attribute, null));
       } else {
-        _controller.formatSelection(attribute);
+        controller.formatSelection(attribute);
       }
     }
   }
 
   void saveViaKeyboard(RawKeyEvent event) {
     if (event.data.isMetaPressed && event.character == 's') {
-      _saveFn();
+      saveFn();
     }
   }
 
   void tempSaveDelta(RawKeyEvent event) {
-    String id = _journalEntity?.meta.id ?? 'none';
+    String id = journalEntity?.meta.id ?? 'none';
 
     EasyDebounce.debounce(
       'tempSaveDelta-$id',
       const Duration(seconds: 2),
       () {
-        Delta delta = deltaFromController(_controller);
+        Delta delta = deltaFromController(controller);
         _editorStateService.saveTempState(id, delta);
       },
     );
@@ -91,28 +81,28 @@ class EditorWidget extends StatelessWidget {
         color: AppColors.editorBgColor,
         child: ConstrainedBox(
           constraints: BoxConstraints(
-            maxHeight: _maxHeight,
+            maxHeight: maxHeight,
           ),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               ToolbarWidget(
-                controller: _controller,
-                saveFn: _saveFn,
-                journalEntity: _journalEntity,
+                controller: controller,
+                saveFn: saveFn,
+                journalEntity: journalEntity,
               ),
               Flexible(
                 child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: _padding),
+                  padding: EdgeInsets.symmetric(horizontal: padding),
                   child: QuillEditor(
-                    controller: _controller,
-                    readOnly: _readOnly,
+                    controller: controller,
+                    readOnly: readOnly,
                     scrollController: ScrollController(),
                     scrollable: true,
-                    focusNode: _focusNode,
-                    autoFocus: _autoFocus,
+                    focusNode: focusNode,
+                    autoFocus: autoFocus,
                     expands: false,
-                    minHeight: _minHeight,
+                    minHeight: minHeight,
                     padding: const EdgeInsets.only(top: 8, bottom: 16),
                     keyboardAppearance: Brightness.dark,
                     customStyles: customEditorStyles(

--- a/lotti/lib/widgets/journal/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor_widget.dart
@@ -1,14 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' hide Text;
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/editor_styles.dart';
 import 'package:lotti/widgets/journal/editor_toolbar.dart';
 
 class EditorWidget extends StatelessWidget {
-  final EditorStateService _editorStateService = getIt<EditorStateService>();
   final JournalEntity? journalEntity;
   final QuillController controller;
   final double maxHeight;
@@ -19,7 +16,7 @@ class EditorWidget extends StatelessWidget {
   final Function saveFn;
   final FocusNode focusNode;
 
-  EditorWidget({
+  const EditorWidget({
     Key? key,
     required this.controller,
     this.journalEntity,

--- a/lotti/lib/widgets/journal/entry_detail_footer.dart
+++ b/lotti/lib/widgets/journal/entry_detail_footer.dart
@@ -19,11 +19,13 @@ import 'duration_widget.dart';
 class EntryDetailFooter extends StatefulWidget {
   final JournalEntity item;
   final Function saveFn;
+  final bool popOnDelete;
 
   const EntryDetailFooter({
     Key? key,
     required this.item,
     required this.saveFn,
+    required this.popOnDelete,
   }) : super(key: key);
 
   @override
@@ -149,10 +151,12 @@ class EntryInfoRow extends StatelessWidget {
   final JournalDb db = getIt<JournalDb>();
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   late final Stream<JournalEntity?> stream = db.watchEntityById(entityId);
+  final bool popOnDelete;
 
   EntryInfoRow({
     Key? key,
     required this.entityId,
+    required this.popOnDelete,
   }) : super(key: key);
 
   @override
@@ -239,7 +243,10 @@ class EntryInfoRow extends StatelessWidget {
 
                   if (result == deleteKey) {
                     persistenceLogic.deleteJournalEntity(liveEntity);
-                    context.router.pop();
+
+                    if (popOnDelete) {
+                      context.router.pop();
+                    }
                   }
                 },
               ),

--- a/lotti/lib/widgets/journal/entry_detail_linked.dart
+++ b/lotti/lib/widgets/journal/entry_detail_linked.dart
@@ -4,7 +4,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/theme.dart';
-import 'package:lotti/widgets/journal/journal_card.dart';
+import 'package:lotti/widgets/journal/entry_details_widget.dart';
 
 class LinkedEntriesWidget extends StatefulWidget {
   const LinkedEntriesWidget({
@@ -68,27 +68,12 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                           _db.removeLink(fromId: fromId, toId: toId);
                         }
 
-                        return item.maybeMap(
-                          journalImage: (JournalImage image) {
-                            return Dismissible(
-                              key: Key('$index'),
-                              onDismissed: unlink,
-                              child: JournalImageCard(
-                                item: image,
-                                index: index,
-                              ),
-                            );
-                          },
-                          orElse: () {
-                            return Dismissible(
-                              key: Key('$index'),
-                              onDismissed: unlink,
-                              child: JournalCard(
-                                item: item,
-                                index: index,
-                              ),
-                            );
-                          },
+                        return Dismissible(
+                          key: Key('$index'),
+                          onDismissed: unlink,
+                          child: EntryDetailWidget(
+                            entryId: item.meta.id,
+                          ),
                         );
                       },
                       growable: true,

--- a/lotti/lib/widgets/journal/entry_detail_linked.dart
+++ b/lotti/lib/widgets/journal/entry_detail_linked.dart
@@ -83,6 +83,7 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                                   child: EntryDetailWidget(
                                     key: Key(item.meta.id),
                                     entryId: item.meta.id,
+                                    popOnDelete: false,
                                   ),
                                 );
                               },

--- a/lotti/lib/widgets/journal/entry_detail_linked.dart
+++ b/lotti/lib/widgets/journal/entry_detail_linked.dart
@@ -46,14 +46,14 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
               return Container();
             } else {
               List<String> itemIds = snapshot.data!;
-              return StreamBuilder<List<JournalEntity>>(
-                  stream: _db.watchJournalEntitiesByIds(itemIds),
+              return StreamBuilder<List<String>>(
+                  stream: _db.watchSortedLinkedEntityIds(itemIds),
                   builder: (context, itemsSnapshot) {
                     if (itemsSnapshot.data == null ||
                         itemsSnapshot.data!.isEmpty) {
                       return Container();
                     } else {
-                      List<JournalEntity> items = itemsSnapshot.data!;
+                      List<String> itemIds = itemsSnapshot.data!;
 
                       return Container(
                         margin: const EdgeInsets.all(8.0),
@@ -67,22 +67,22 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                               ),
                             ),
                             ...List.generate(
-                              items.length,
+                              itemIds.length,
                               (int index) {
-                                JournalEntity item = items.elementAt(index);
+                                String itemId = itemIds.elementAt(index);
 
                                 void unlink(DismissDirection direction) {
                                   String fromId = widget.item.meta.id;
-                                  String toId = item.meta.id;
+                                  String toId = itemId;
                                   _db.removeLink(fromId: fromId, toId: toId);
                                 }
 
                                 return Dismissible(
-                                  key: Key(item.meta.id),
+                                  key: Key(itemId),
                                   onDismissed: unlink,
                                   child: EntryDetailWidget(
-                                    key: Key(item.meta.id),
-                                    entryId: item.meta.id,
+                                    key: Key(itemId),
+                                    entryId: itemId,
                                     popOnDelete: false,
                                   ),
                                 );

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -13,6 +13,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
@@ -45,13 +46,13 @@ class EntryDetailWidget extends StatefulWidget {
 class _EntryDetailWidgetState extends State<EntryDetailWidget> {
   final JournalDb _db = getIt<JournalDb>();
   final FocusNode _focusNode = FocusNode();
-  bool showDetails = false;
+  final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
+  final EditorStateService _editorStateService = getIt<EditorStateService>();
 
   late final Stream<JournalEntity?> _stream =
       _db.watchEntityById(widget.entryId);
 
-  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
-
+  bool showDetails = false;
   Directory? docDir;
   double editorHeight = (Platform.isIOS || Platform.isAndroid) ? 160 : 240;
   double imageTextEditorHeight =
@@ -97,10 +98,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
             makeController(serializedQuill: entryText?.quill);
 
         void saveText() {
-          EntryText entryText = entryTextFromController(_controller);
-          HapticFeedback.heavyImpact();
-
-          persistenceLogic.updateJournalEntityText(item.meta.id, entryText);
+          _editorStateService.saveState(item.meta.id, _controller);
         }
 
         return Container(
@@ -216,7 +214,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                         formKey.currentState?.save();
                         final formData = formKey.currentState?.value;
                         if (formData == null) {
-                          persistenceLogic.updateTask(
+                          _persistenceLogic.updateTask(
                             entryText: entryTextFromController(_controller),
                             journalEntityId: task.meta.id,
                             taskData: task.data,
@@ -244,7 +242,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                           status: taskStatusFromString(status),
                         );
 
-                        persistenceLogic.updateTask(
+                        _persistenceLogic.updateTask(
                           entryText: entryTextFromController(_controller),
                           journalEntityId: task.meta.id,
                           taskData: updatedData,

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -29,10 +29,12 @@ import 'package:path_provider/path_provider.dart';
 class EntryDetailWidget extends StatefulWidget {
   final String entryId;
   final bool readOnly;
+  final bool popOnDelete;
 
   const EntryDetailWidget({
     Key? key,
     @PathParam() required this.entryId,
+    required this.popOnDelete,
     this.readOnly = false,
   }) : super(key: key);
 
@@ -264,11 +266,15 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: EntryInfoRow(entityId: item.meta.id),
+                    child: EntryInfoRow(
+                      entityId: item.meta.id,
+                      popOnDelete: widget.popOnDelete,
+                    ),
                   ),
                   EntryDetailFooter(
                     item: item,
                     saveFn: saveText,
+                    popOnDelete: widget.popOnDelete,
                   ),
                 ],
               ),

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -1,0 +1,281 @@
+import 'dart:io';
+
+import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_quill/flutter_quill.dart' hide Text;
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/audio/audio_player.dart';
+import 'package:lotti/widgets/journal/editor_tools.dart';
+import 'package:lotti/widgets/journal/editor_widget.dart';
+import 'package:lotti/widgets/journal/entry_detail_footer.dart';
+import 'package:lotti/widgets/journal/entry_image_widget.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:lotti/widgets/journal/helpers.dart';
+import 'package:lotti/widgets/journal/tags_widget.dart';
+import 'package:lotti/widgets/misc/survey_summary.dart';
+import 'package:lotti/widgets/tasks/task_form.dart';
+import 'package:path_provider/path_provider.dart';
+
+class EntryDetailWidget extends StatefulWidget {
+  final String entryId;
+  final bool readOnly;
+
+  const EntryDetailWidget({
+    Key? key,
+    @PathParam() required this.entryId,
+    this.readOnly = false,
+  }) : super(key: key);
+
+  @override
+  State<EntryDetailWidget> createState() => _EntryDetailWidgetState();
+}
+
+class _EntryDetailWidgetState extends State<EntryDetailWidget> {
+  final JournalDb _db = getIt<JournalDb>();
+  final FocusNode _focusNode = FocusNode();
+  bool showDetails = false;
+
+  late final Stream<JournalEntity?> _stream =
+      _db.watchEntityById(widget.entryId);
+
+  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
+
+  Directory? docDir;
+  double editorHeight = (Platform.isIOS || Platform.isAndroid) ? 160 : 240;
+  double imageTextEditorHeight =
+      (Platform.isIOS || Platform.isAndroid) ? 160 : 240;
+
+  @override
+  void initState() {
+    super.initState();
+
+    getApplicationDocumentsDirectory().then((value) {
+      setState(() {
+        docDir = value;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<JournalEntity?>(
+      stream: _stream,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<JournalEntity?> snapshot,
+      ) {
+        JournalEntity? item = snapshot.data;
+        if (item == null) {
+          return const SizedBox.shrink();
+        }
+
+        EntryText? entryText = item.map(
+          journalEntry: (item) => item.entryText,
+          journalImage: (item) => item.entryText,
+          journalAudio: (item) => item.entryText,
+          task: (item) => item.entryText,
+          quantitative: (_) => null,
+          measurement: (item) => item.entryText,
+          workout: (item) => item.entryText,
+          habitCompletion: (item) => item.entryText,
+          survey: (_) => null,
+        );
+
+        QuillController _controller =
+            makeController(serializedQuill: entryText?.quill);
+
+        void saveText() {
+          EntryText entryText = entryTextFromController(_controller);
+          HapticFeedback.heavyImpact();
+
+          persistenceLogic.updateJournalEntityText(item.meta.id, entryText);
+        }
+
+        return Container(
+          margin: const EdgeInsets.symmetric(
+            horizontal: 12.0,
+            vertical: 4.0,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8.0),
+            child: Container(
+              color: AppColors.headerBgColor,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TagsWidget(item: item),
+                  ),
+                  item.map(
+                    journalAudio: (JournalAudio audio) {
+                      return Column(
+                        children: [
+                          const AudioPlayerWidget(),
+                          EditorWidget(
+                            controller: _controller,
+                            journalEntity: item,
+                            focusNode: _focusNode,
+                            saveFn: saveText,
+                          ),
+                        ],
+                      );
+                    },
+                    journalImage: (JournalImage image) {
+                      return Column(
+                        children: [
+                          Container(
+                            width: MediaQuery.of(context).size.width,
+                            color: Colors.black,
+                            child: EntryImageWidget(
+                              focusNode: _focusNode,
+                              journalImage: image,
+                            ),
+                          ),
+                          EditorWidget(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            readOnly: widget.readOnly,
+                            journalEntity: item,
+                            saveFn: saveText,
+                          ),
+                        ],
+                      );
+                    },
+                    journalEntry: (JournalEntry journalEntry) {
+                      return EditorWidget(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        readOnly: widget.readOnly,
+                        saveFn: saveText,
+                        journalEntity: item,
+                      );
+                    },
+                    measurement: (MeasurementEntry entry) {
+                      return EditorWidget(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        readOnly: widget.readOnly,
+                        saveFn: saveText,
+                        journalEntity: item,
+                      );
+                    },
+                    workout: (WorkoutEntry workout) {
+                      WorkoutData data = workout.data;
+                      return Column(
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: EntryTextWidget(data.toString()),
+                          ),
+                          EditorWidget(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            readOnly: widget.readOnly,
+                            saveFn: saveText,
+                            journalEntity: item,
+                          ),
+                        ],
+                      );
+                    },
+                    survey: (SurveyEntry surveyEntry) =>
+                        SurveySummaryWidget(surveyEntry),
+                    quantitative: (qe) => qe.data.map(
+                      cumulativeQuantityData: (qd) => Padding(
+                        padding: const EdgeInsets.all(24.0),
+                        child: InfoText(
+                          'End: ${df.format(qe.meta.dateTo)}'
+                          '\n${formatType(qd.dataType)}: '
+                          '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+                        ),
+                      ),
+                      discreteQuantityData: (qd) => Padding(
+                        padding: const EdgeInsets.all(24.0),
+                        child: InfoText(
+                          'End: ${df.format(qe.meta.dateTo)}'
+                          '\n${formatType(qd.dataType)}: '
+                          '${nf.format(qd.value)} ${formatUnit(qd.unit)}',
+                        ),
+                      ),
+                    ),
+                    task: (Task task) {
+                      final formKey = GlobalKey<FormBuilderState>();
+
+                      void saveText() {
+                        formKey.currentState?.save();
+                        final formData = formKey.currentState?.value;
+                        if (formData == null) {
+                          persistenceLogic.updateTask(
+                            entryText: entryTextFromController(_controller),
+                            journalEntityId: task.meta.id,
+                            taskData: task.data,
+                          );
+                          HapticFeedback.heavyImpact();
+
+                          return;
+                        }
+                        final DateTime due = formData['due'];
+                        final String title = formData['title'];
+                        final DateTime dt = formData['estimate'];
+                        final String status = formData['status'];
+
+                        final Duration estimate = Duration(
+                          hours: dt.hour,
+                          minutes: dt.minute,
+                        );
+
+                        HapticFeedback.heavyImpact();
+
+                        TaskData updatedData = task.data.copyWith(
+                          title: title,
+                          estimate: estimate,
+                          due: due,
+                          status: taskStatusFromString(status),
+                        );
+
+                        persistenceLogic.updateTask(
+                          entryText: entryTextFromController(_controller),
+                          journalEntityId: task.meta.id,
+                          taskData: updatedData,
+                        );
+                      }
+
+                      return TaskForm(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        saveFn: saveText,
+                        formKey: formKey,
+                        data: task.data,
+                        task: task,
+                      );
+                    },
+                    habitCompletion: (HabitCompletionEntry value) {
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: EntryInfoRow(entityId: item.meta.id),
+                  ),
+                  EntryDetailFooter(
+                    item: item,
+                    saveFn: saveText,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -26,6 +26,7 @@ import 'package:lotti/widgets/journal/tags_widget.dart';
 import 'package:lotti/widgets/misc/survey_summary.dart';
 import 'package:lotti/widgets/tasks/task_form.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:tuple/tuple.dart';
 
 class EntryDetailWidget extends StatefulWidget {
   final String entryId;
@@ -96,6 +97,10 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
 
         QuillController _controller =
             makeController(serializedQuill: entryText?.quill);
+
+        _controller.changes.listen((Tuple3<Delta, Delta, ChangeSource> event) {
+          _editorStateService.saveTempState(item.meta.id, _controller);
+        });
 
         void saveText() {
           _editorStateService.saveState(item.meta.id, _controller);

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -140,7 +140,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.1.10"
   build_runner_core:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.4"
+    version: "8.2.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -378,7 +378,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.12.0"
+    version: "4.14.0"
   dart_geohash:
     dependency: "direct main"
     description:
@@ -1112,7 +1112,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.6"
   just_audio:
     dependency: "direct main"
     description:
@@ -1210,7 +1210,7 @@ packages:
       name: lottie
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -1681,14 +1681,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/lotti/pubspec.lock
+++ b/lotti/pubspec.lock
@@ -472,6 +472,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.2"
+  easy_debounce:
+    dependency: "direct main"
+    description:
+      name: easy_debounce
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2+1"
   encrypt:
     dependency: transitive
     description:

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+651
+version: 0.6.48+652
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+643
+version: 0.6.48+644
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+642
+version: 0.6.48+643
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+646
+version: 0.6.48+647
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+650
+version: 0.6.48+651
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+644
+version: 0.6.48+645
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -53,6 +53,7 @@ dependencies:
   dart_geohash: ^2.0.1
   device_info_plus: ^3.1.0
   drift: ^1.1.0
+  easy_debounce: ^2.0.2+1
   enum_to_string: ^2.0.1
   equatable: ^2.0.3
   exif: ^3.0.1

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+647
+version: 0.6.48+648
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+649
+version: 0.6.48+650
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+645
+version: 0.6.48+646
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.47+640
+version: 0.6.48+641
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+648
+version: 0.6.48+649
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+641
+version: 0.6.48+642
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR changes the rendering of entries with linked entries (such as tasks) to show linked entries in edit mode. It introduces the `EditorStateService` which the editor now exclusively interacts with. This service tracks if an entry is unsaved, which so far is only used to create a stream for each open editor, with a boolean that is used to determine if the editor save button should displayed in red. Going forward, the tracked changes can also be used for temporarily persisting unsaved changes in entry text, e.g. so that they don't get lost if the user navigates elsewhere (or the application is closed),