### PR TITLE
Editor state store unsaved

### DIFF
--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -18,8 +18,7 @@ class EditorStateService {
   EditorStateService();
 
   Stream<bool> getUnsavedStream(String? id) {
-    StreamController<bool> unsavedStreamController =
-        StreamController<bool>.broadcast();
+    StreamController<bool> unsavedStreamController = StreamController<bool>();
 
     if (id != null) {
       StreamController<bool>? existing = unsavedStreamById[id];
@@ -30,6 +29,8 @@ class EditorStateService {
 
       unsavedStreamById[id] = unsavedStreamController;
     }
+
+    unsavedStreamController.add(editorStateById[id] != null);
 
     return unsavedStreamController.stream;
   }
@@ -60,6 +61,8 @@ class EditorStateService {
     await _persistenceLogic.updateJournalEntityText(id, entryText);
 
     StreamController<bool>? unsavedStreamController = unsavedStreamById[id];
+    editorStateById.remove(id);
+
     if (unsavedStreamController != null) {
       unsavedStreamController.add(false);
     }

--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -35,6 +35,10 @@ class EditorStateService {
     return unsavedStreamController.stream;
   }
 
+  String? getDelta(String? id) {
+    return editorStateById[id];
+  }
+
   void saveTempState(String id, QuillController controller) {
     Delta delta = deltaFromController(controller);
     String json = quillJsonFromDelta(delta);

--- a/lotti/lib/services/editor_state_service.dart
+++ b/lotti/lib/services/editor_state_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/task.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/widgets/journal/editor_tools.dart';
@@ -61,8 +62,30 @@ class EditorStateService {
   void saveState(String id, QuillController controller) async {
     EasyDebounce.cancel('tempSaveDelta-$id');
     EntryText entryText = entryTextFromController(controller);
-    debugPrint('saveState $id ${entryText.toJson()}');
     await _persistenceLogic.updateJournalEntityText(id, entryText);
+
+    StreamController<bool>? unsavedStreamController = unsavedStreamById[id];
+    editorStateById.remove(id);
+
+    if (unsavedStreamController != null) {
+      unsavedStreamController.add(false);
+    }
+
+    HapticFeedback.heavyImpact();
+  }
+
+  void saveTask({
+    required String id,
+    required QuillController controller,
+    required TaskData taskData,
+  }) async {
+    EasyDebounce.cancel('tempSaveDelta-$id');
+
+    _persistenceLogic.updateTask(
+      entryText: entryTextFromController(controller),
+      journalEntityId: id,
+      taskData: taskData,
+    );
 
     StreamController<bool>? unsavedStreamController = unsavedStreamById[id];
     editorStateById.remove(id);

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -95,8 +95,10 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
           survey: (_) => null,
         );
 
-        QuillController _controller =
-            makeController(serializedQuill: entryText?.quill);
+        QuillController _controller = makeController(
+          serializedQuill:
+              _editorStateService.getDelta(item.meta.id) ?? entryText?.quill,
+        );
 
         _controller.changes.listen((Tuple3<Delta, Delta, ChangeSource> event) {
           _editorStateService.saveTempState(item.meta.id, _controller);

--- a/lotti/lib/widgets/journal/entry_details_widget.dart
+++ b/lotti/lib/widgets/journal/entry_details_widget.dart
@@ -12,7 +12,6 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
@@ -47,7 +46,6 @@ class EntryDetailWidget extends StatefulWidget {
 class _EntryDetailWidgetState extends State<EntryDetailWidget> {
   final JournalDb _db = getIt<JournalDb>();
   final FocusNode _focusNode = FocusNode();
-  final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
   final EditorStateService _editorStateService = getIt<EditorStateService>();
 
   late final Stream<JournalEntity?> _stream =
@@ -221,12 +219,11 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                         formKey.currentState?.save();
                         final formData = formKey.currentState?.value;
                         if (formData == null) {
-                          _persistenceLogic.updateTask(
-                            entryText: entryTextFromController(_controller),
-                            journalEntityId: task.meta.id,
+                          _editorStateService.saveTask(
+                            id: item.meta.id,
+                            controller: _controller,
                             taskData: task.data,
                           );
-                          HapticFeedback.heavyImpact();
 
                           return;
                         }
@@ -249,9 +246,9 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                           status: taskStatusFromString(status),
                         );
 
-                        _persistenceLogic.updateTask(
-                          entryText: entryTextFromController(_controller),
-                          journalEntityId: task.meta.id,
+                        _editorStateService.saveTask(
+                          id: item.meta.id,
+                          controller: _controller,
                           taskData: updatedData,
                         );
                       }

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.48+652
+version: 0.6.49+653
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.49+654
+version: 0.6.49+655
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.49+653
+version: 0.6.49+654
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds using a draft for the editor state initialization if a draft exists, or otherwise the persisted version. At this stage, drafts do not survive app restart. For that, the `EditorStateService` can be backed by database persistence later on.