### PR TITLE
Remove durations for photos - photos are snapshots

### DIFF
--- a/lotti/lib/widgets/journal/duration_widget.dart
+++ b/lotti/lib/widgets/journal/duration_widget.dart
@@ -32,6 +32,10 @@ class DurationWidget extends StatelessWidget {
         BuildContext context,
         AsyncSnapshot<JournalEntity?> snapshot,
       ) {
+        if (item is JournalImage) {
+          return const SizedBox.shrink();
+        }
+
         bool isRecent =
             DateTime.now().difference(item.meta.dateFrom).inHours < 12;
 

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.59+680
+version: 0.6.60+681
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR removes the display of the duration for image entries since they don't make sense. Photos are snapshots. If anything, the sensible duration of a photo is their exposure time, but knowing that is not very useful in this context.