### PR TITLE
Fix entry routes after renaming PathParam

### DIFF
--- a/lotti/lib/routes/journal_routes.dart
+++ b/lotti/lib/routes/journal_routes.dart
@@ -16,7 +16,7 @@ const AutoRoute journalRoutes = AutoRoute(
       page: JournalPage,
     ),
     AutoRoute(
-      path: ':entryId',
+      path: ':itemId',
       page: EntryDetailPage,
     ),
     AutoRoute(

--- a/lotti/lib/routes/task_routes.dart
+++ b/lotti/lib/routes/task_routes.dart
@@ -13,7 +13,7 @@ const AutoRoute taskRoutes = AutoRoute(
       page: TasksPage,
     ),
     AutoRoute(
-      path: ':entryId',
+      path: ':itemId',
       page: EntryDetailPage,
     ),
     AutoRoute(

--- a/lotti/lib/widgets/misc/time_recording_indicator.dart
+++ b/lotti/lib/widgets/misc/time_recording_indicator.dart
@@ -32,8 +32,8 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
 
         return GestureDetector(
           onTap: () {
-            String entryId = current.meta.id;
-            context.router.pushNamed('/journal/$entryId');
+            String itemId = current.meta.id;
+            context.router.pushNamed('/journal/$itemId');
           },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.6.62+687
+version: 0.6.63+688
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR fixes the entry details page, which showed a blank page after recently renaming the `itemId` path parameter.