### PR TITLE
Navigation persistence  #1

### DIFF
--- a/lotti/lib/get_it.dart
+++ b/lotti/lib/get_it.dart
@@ -3,6 +3,7 @@ import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/link_service.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/services/tags_service.dart';
@@ -37,4 +38,5 @@ void registerSingletons() {
   getIt.registerSingleton<EditorStateService>(EditorStateService());
   getIt.registerSingleton<Maintenance>(Maintenance());
   getIt.registerSingleton<AppRouter>(AppRouter());
+  getIt.registerSingleton<NavService>(NavService());
 }

--- a/lotti/lib/main.dart
+++ b/lotti/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:lotti/blocs/sync/outbox_cubit.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/routes/observer.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/screenshots.dart';
@@ -93,7 +94,9 @@ class LottiApp extends StatelessWidget {
           primarySwatch: Colors.grey,
         ),
         debugShowCheckedModeBanner: true,
-        routerDelegate: router.delegate(),
+        routerDelegate: router.delegate(
+          navigatorObservers: () => [NavObserver()],
+        ),
         routeInformationParser: router.defaultRouteParser(),
       ),
     );

--- a/lotti/lib/main.dart
+++ b/lotti/lib/main.dart
@@ -13,7 +13,6 @@ import 'package:lotti/blocs/sync/outbox_cubit.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/routes/observer.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/screenshots.dart';
@@ -95,7 +94,7 @@ class LottiApp extends StatelessWidget {
         ),
         debugShowCheckedModeBanner: true,
         routerDelegate: router.delegate(
-          navigatorObservers: () => [NavObserver()],
+          navigatorObservers: () => [],
         ),
         routeInformationParser: router.defaultRouteParser(),
       ),

--- a/lotti/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lotti/lib/pages/dashboards/dashboards_list_page.dart
@@ -1,9 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 
 class DashboardsListPage extends StatefulWidget {
@@ -96,11 +95,7 @@ class DashboardCard extends StatelessWidget {
         ),
         enabled: true,
         onTap: () {
-          context.router.push(
-            DashboardRoute(
-              dashboardId: dashboard.id,
-            ),
-          );
+          pushNamedRoute('/dashboards/${dashboard.id}');
         },
       ),
     );

--- a/lotti/lib/pages/home_page.dart
+++ b/lotti/lib/pages/home_page.dart
@@ -13,6 +13,10 @@ import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 class HomePage extends StatelessWidget {
   const HomePage({Key? key}) : super(key: key);
 
+  void onNavigateCallback(RouteMatch route, bool initial) {
+    debugPrint('onNavigateCallback $route $initial');
+  }
+
   @override
   Widget build(BuildContext context) {
     return AutoTabsScaffold(
@@ -50,7 +54,7 @@ class HomePage extends StatelessWidget {
         SettingsRouter(),
         //TutorialRouter(),
       ],
-      bottomNavigationBuilder: (_, tabsRouter) {
+      bottomNavigationBuilder: (_, TabsRouter tabsRouter) {
         return BottomNavigationBar(
           type: BottomNavigationBarType.fixed,
           backgroundColor: AppColors.headerBgColor,

--- a/lotti/lib/pages/my_day.dart
+++ b/lotti/lib/pages/my_day.dart
@@ -1,8 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
@@ -91,7 +91,7 @@ class MyDayPage extends StatelessWidget {
             cal.appointments?.forEach((element) {
               Meeting meeting = element as Meeting;
               String entryId = meeting.journalEntity.meta.id;
-              context.router.pushNamed('/journal/$entryId');
+              pushNamedRoute('/journal/$entryId');
             });
           },
         );

--- a/lotti/lib/pages/settings/advanced_settings_page.dart
+++ b/lotti/lib/pages/settings/advanced_settings_page.dart
@@ -1,10 +1,9 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/pages/settings/outbox_badge.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class AdvancedSettingsPage extends StatelessWidget {
@@ -27,7 +26,7 @@ class AdvancedSettingsPage extends StatelessWidget {
             icon: const SettingsIcon(Icons.sync),
             title: localizations.settingsSyncCfgTitle,
             onTap: () {
-              context.router.push(const SyncSettingsRoute());
+              pushNamedRoute('/settings/sync_settings');
             },
           ),
           SettingsCard(
@@ -36,35 +35,35 @@ class AdvancedSettingsPage extends StatelessWidget {
             ),
             title: localizations.settingsSyncOutboxTitle,
             onTap: () {
-              context.router.push(const OutboxMonitorRoute());
+              pushNamedRoute('/settings/outbox_monitor');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.emoticonConfusedOutline),
             title: localizations.settingsConflictsTitle,
             onTap: () {
-              context.router.push(const ConflictsRoute());
+              pushNamedRoute('/settings/conflicts');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.informationOutline),
             title: localizations.settingsLogsTitle,
             onTap: () {
-              context.router.push(const LoggingRoute());
+              pushNamedRoute('/settings/logging');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.broom),
             title: localizations.settingsMaintenanceTitle,
             onTap: () {
-              context.router.push(const MaintenanceRoute());
+              pushNamedRoute('/settings/maintenance');
             },
           ),
           SettingsCard(
-            icon: const SettingsIcon(MdiIcons.broom),
+            icon: const SettingsIcon(MdiIcons.slide),
             title: localizations.settingsPlaygroundTitle,
             onTap: () {
-              context.router.push(const DevPlaygroundRoute());
+              pushNamedRoute('/settings/playground');
             },
           ),
         ],

--- a/lotti/lib/pages/settings/dashboards/dashboard_details_page.dart
+++ b/lotti/lib/pages/settings/dashboards/dashboard_details_page.dart
@@ -16,6 +16,7 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/pages/settings/dashboards/chart_multi_select.dart';
 import 'package:lotti/pages/settings/dashboards/dashboard_item_card.dart';
 import 'package:lotti/pages/settings/form_text_field.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/charts/dashboard_health_config.dart';
@@ -270,7 +271,7 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
 
         Future<void> saveAndViewDashboard() async {
           await saveDashboard();
-          context.router.pushNamed('/dashboards/${widget.dashboard.id}');
+          pushNamedRoute('/dashboards/${widget.dashboard.id}');
         }
 
         Future<void> copyDashboard() async {

--- a/lotti/lib/pages/settings/dev_playground_page.dart
+++ b/lotti/lib/pages/settings/dev_playground_page.dart
@@ -1,8 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class DevPlaygroundPage extends StatelessWidget {
@@ -25,7 +25,7 @@ class DevPlaygroundPage extends StatelessWidget {
             icon: const SettingsIcon(MdiIcons.slide),
             title: localizations.settingsPlaygroundTutorialTitle,
             onTap: () {
-              context.router.pushNamed('/settings/tutorial');
+              pushNamedRoute('/settings/tutorial');
             },
           ),
         ],

--- a/lotti/lib/pages/settings/logging_page.dart
+++ b/lotti/lib/pages/settings/logging_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -71,11 +71,7 @@ class LogLineCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: () {
-        context.router.push(
-          LogDetailRoute(
-            logEntryId: logEntry.id,
-          ),
-        );
+        pushNamedRoute('/settings/logging/${logEntry.id}');
       },
       child: Padding(
         padding: const EdgeInsets.all(2.0),

--- a/lotti/lib/pages/settings/settings_page.dart
+++ b/lotti/lib/pages/settings/settings_page.dart
@@ -1,9 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -39,42 +38,42 @@ class _SettingsPageState extends State<SettingsPage> {
             icon: const SettingsIcon(MdiIcons.tagOutline),
             title: localizations.settingsTagsTitle,
             onTap: () {
-              context.router.push(const TagsRoute());
+              pushNamedRoute('/settings/tags');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(Icons.insights_outlined),
             title: localizations.settingsDashboardsTitle,
             onTap: () {
-              context.router.push(const DashboardSettingsRoute());
+              pushNamedRoute('/settings/dashboards');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.tapeMeasure),
             title: localizations.settingsMeasurablesTitle,
             onTap: () {
-              context.router.push(const MeasurablesRoute());
+              pushNamedRoute('/settings/measurables');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.heartOutline),
             title: localizations.settingsHealthImportTitle,
             onTap: () {
-              context.router.push(const HealthImportRoute());
+              pushNamedRoute('/settings/health_import');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.flagOutline),
             title: localizations.settingsFlagsTitle,
             onTap: () {
-              context.router.push(const FlagsRoute());
+              pushNamedRoute('/settings/flags');
             },
           ),
           SettingsCard(
             icon: const SettingsIcon(MdiIcons.alertRhombusOutline),
             title: localizations.settingsAdvancedTitle,
             onTap: () {
-              context.router.push(const AdvancedSettingsRoute());
+              pushNamedRoute('/settings/advanced');
             },
           ),
         ],

--- a/lotti/lib/pages/tasks_page.dart
+++ b/lotti/lib/pages/tasks_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,6 +9,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/journal/journal_card.dart';
@@ -361,7 +361,7 @@ class AddTask extends StatelessWidget {
         backgroundColor: AppColors.actionColor,
         onPressed: () {
           String? linkedId;
-          context.router.pushNamed('/tasks/create/$linkedId');
+          pushNamedRoute('/tasks/create/$linkedId');
         },
       ),
     );

--- a/lotti/lib/routes/observer.dart
+++ b/lotti/lib/routes/observer.dart
@@ -1,0 +1,21 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/widgets.dart';
+
+class NavObserver extends AutoRouterObserver {
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    super.didPush(route, previousRoute);
+    print('New route pushed: ${route.settings}');
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    super.didPop(route, previousRoute);
+    print('Route popped: ${route.settings}');
+  }
+
+  @override
+  void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
+    print('Tab route re-visited: ${route.name}');
+  }
+}

--- a/lotti/lib/routes/observer.dart
+++ b/lotti/lib/routes/observer.dart
@@ -5,17 +5,17 @@ class NavObserver extends AutoRouterObserver {
   @override
   void didPush(Route route, Route? previousRoute) {
     super.didPush(route, previousRoute);
-    print('New route pushed: ${route.settings}');
+    debugPrint('New route pushed: ${route.settings}');
   }
 
   @override
   void didPop(Route route, Route? previousRoute) {
     super.didPop(route, previousRoute);
-    print('Route popped: ${route.settings}');
+    debugPrint('Route popped: ${route.settings}');
   }
 
   @override
   void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
-    print('Tab route re-visited: ${route.name}');
+    debugPrint('Tab route re-visited: ${route.name}');
   }
 }

--- a/lotti/lib/routes/settings_routes.dart
+++ b/lotti/lib/routes/settings_routes.dart
@@ -82,7 +82,7 @@ const AutoRoute settingsRoutes = AutoRoute(
       page: LoggingPage,
     ),
     AutoRoute(
-      path: 'logging/:dashboardId',
+      path: 'logging/:logEntryId',
       page: LogDetailPage,
     ),
     AutoRoute(

--- a/lotti/lib/services/nav_service.dart
+++ b/lotti/lib/services/nav_service.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/sync/secure_storage.dart';
+
+const String lastRouteKey = 'LAST_ROUTE_KEY';
+
+class NavService {
+  NavService() {
+    restoreRoute();
+  }
+
+  void restoreRoute() async {
+    String? route = await SecureStorage.readValue(lastRouteKey);
+    if (route != null) {
+      Timer(const Duration(milliseconds: 100), () {
+        getIt<AppRouter>().pushNamed(route);
+        debugPrint('restoreRoute: $route');
+      });
+    }
+  }
+}
+
+void pushNamedRoute(String route) {
+  debugPrint('pushNamedRoute: $route');
+  SecureStorage.writeValue(lastRouteKey, route);
+  getIt<AppRouter>().pushNamed(route);
+}

--- a/lotti/lib/widgets/charts/dashboard_survey_chart.dart
+++ b/lotti/lib/widgets/charts/dashboard_survey_chart.dart
@@ -1,12 +1,12 @@
 import 'dart:core';
 
-import 'package:auto_route/auto_route.dart';
 import 'package:charts_flutter/flutter.dart' as charts;
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/charts/dashboard_survey_data.dart';
 import 'package:lotti/widgets/charts/utils.dart';
@@ -46,7 +46,7 @@ class DashboardSurveyChart extends StatelessWidget {
         List<JournalEntity?>? items = snapshot.data ?? [];
 
         void onDoubleTap() async {
-          context.router.pushNamed('/journal/create_survey/${null}');
+          pushNamedRoute('/journal/create_survey/${null}');
         }
 
         return GestureDetector(

--- a/lotti/lib/widgets/create/add_actions.dart
+++ b/lotti/lib/widgets/create/add_actions.dart
@@ -10,6 +10,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/image_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/screenshots.dart';
@@ -92,7 +93,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
         backgroundColor: AppColors.actionColor,
         onPressed: () {
           String? linkedId = widget.linked?.meta.id;
-          context.router.pushNamed('/journal/create_survey/$linkedId');
+          pushNamedRoute('/journal/create_survey/$linkedId');
         },
       ),
     );
@@ -131,7 +132,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
             );
           } else {
             String? linkedId = widget.linked?.meta.id;
-            context.router.pushNamed('/journal/create/$linkedId');
+            pushNamedRoute('/journal/create/$linkedId');
           }
         },
       ),
@@ -159,7 +160,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
               }
             } else {
               String? linkedId = widget.linked?.meta.id;
-              context.router.pushNamed('/journal/create/$linkedId');
+              pushNamedRoute('/journal/create/$linkedId');
             }
           },
         ),
@@ -177,7 +178,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           backgroundColor: AppColors.actionColor,
           onPressed: () {
             String? linkedId = widget.linked?.meta.id;
-            context.router.pushNamed('/journal/record_audio/$linkedId');
+            pushNamedRoute('/journal/record_audio/$linkedId');
 
             context.read<AudioRecorderCubit>().record(
                   linkedId: widget.linked?.meta.id,
@@ -197,7 +198,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
         backgroundColor: AppColors.actionColor,
         onPressed: () {
           String? linkedId = widget.linked?.meta.id;
-          context.router.pushNamed('/tasks/create/$linkedId');
+          pushNamedRoute('/tasks/create/$linkedId');
         },
       ),
     );

--- a/lotti/lib/widgets/journal/journal_card.dart
+++ b/lotti/lib/widgets/journal/journal_card.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getwidget/components/list_tile/gf_list_tile.dart';
@@ -6,7 +5,7 @@ import 'package:lotti/blocs/audio/player_cubit.dart';
 import 'package:lotti/blocs/audio/player_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/card_image_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
@@ -195,7 +194,7 @@ class JournalCard extends StatelessWidget {
               context.read<AudioPlayerCubit>().setAudioNote(audioNote);
             });
 
-            context.router.push(EntryDetailRoute(itemId: item.meta.id));
+            pushNamedRoute('/journal/${item.meta.id}');
           },
         ),
       );
@@ -266,8 +265,7 @@ class JournalImageCard extends StatelessWidget {
               item.mapOrNull(journalAudio: (JournalAudio audioNote) {
                 context.read<AudioPlayerCubit>().setAudioNote(audioNote);
               });
-              String entryId = item.meta.id;
-              context.router.push(EntryDetailRoute(itemId: entryId));
+              pushNamedRoute('/journal/${item.meta.id}');
             },
           ),
         ),

--- a/lotti/lib/widgets/journal/tags_widget.dart
+++ b/lotti/lib/widgets/journal/tags_widget.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -8,6 +7,7 @@ import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/platform.dart';
@@ -310,7 +310,7 @@ class TagWidget extends StatelessWidget {
 
     return GestureDetector(
       onDoubleTap: () {
-        context.router.pushNamed('/settings/tags/${tagEntity.id}');
+        pushNamedRoute('/settings/tags/${tagEntity.id}');
       },
       child: ClipRRect(
         borderRadius: BorderRadius.circular(chipBorderRadius),

--- a/lotti/lib/widgets/misc/time_recording_indicator.dart
+++ b/lotti/lib/widgets/misc/time_recording_indicator.dart
@@ -1,7 +1,7 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
@@ -33,7 +33,7 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
         return GestureDetector(
           onTap: () {
             String itemId = current.meta.id;
-            context.router.pushNamed('/journal/$itemId');
+            pushNamedRoute('/journal/$itemId');
           },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.2+692
+version: 0.7.2+693
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.1+691
+version: 0.7.2+692
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR adds a first, rather naive, attempt at persisting the latest route and restoring that on next application start, such as after a potentially automatic update. No history is persisted yet. When going back from whatever the last route was, the user will land on the journal page. This can be improved later.