### PR TITLE
Revert "Remove durations for photos - photos are snapshots"

### DIFF
--- a/lotti/lib/widgets/journal/duration_widget.dart
+++ b/lotti/lib/widgets/journal/duration_widget.dart
@@ -32,10 +32,6 @@ class DurationWidget extends StatelessWidget {
         BuildContext context,
         AsyncSnapshot<JournalEntity?> snapshot,
       ) {
-        if (item is JournalImage) {
-          return const SizedBox.shrink();
-        }
-
         bool isRecent =
             DateTime.now().difference(item.meta.dateFrom).inHours < 12;
 

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.2+693
+version: 0.7.3+694
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This reverts commit 514e004b306367a151f7b6cc5071f4a1a5ccebd0. The durations on images are useful, after all.