### PR TITLE
Disable sync when not configured

### DIFF
--- a/lotti/lib/sync/inbox_service.dart
+++ b/lotti/lib/sync/inbox_service.dart
@@ -146,14 +146,23 @@ class SyncInboxService {
   }
 
   void _startPeriodicFetching() async {
-    timer?.cancel();
-    _fetchInbox();
-    timer = Timer.periodic(
-      const Duration(seconds: 15),
-      (timer) async {
-        _fetchInbox();
-      },
-    );
+    SyncConfig? syncConfig = await _syncConfigService.getSyncConfig();
+
+    if (syncConfig == null) {
+      _loggingDb.captureEvent(
+          'Sync config missing -> periodic fetching not started',
+          domain: 'OUTBOX_CUBIT');
+      return;
+    } else {
+      timer?.cancel();
+      _fetchInbox();
+      timer = Timer.periodic(
+        const Duration(seconds: 15),
+        (timer) async {
+          _fetchInbox();
+        },
+      );
+    }
   }
 
   void _stopPeriodicFetching() async {

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.12+745
+version: 0.7.13+746
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR disables sync when it is not configured, saving CPU cycles and battery for useless periodic function calls.