### PR TITLE
Remove autofocus from task editor

### DIFF
--- a/lotti/CHANGELOG.md
+++ b/lotti/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- No autofocus on task text
+
+## [0.7.15] - 2022-04-27
 ### Added:
-- adaptive max height for images
+- Adaptive max height for images
 
 ## [0.7.14] - 2022-04-27
 ### Fixed:

--- a/lotti/Makefile
+++ b/lotti/Makefile
@@ -139,7 +139,7 @@ macos_fastlane_export:
 	cd macos && fastlane package && cd ..
 
 .PHONY: macos
-macos: macos_build macos_fastlane_beta macos_export
+macos: macos_build macos_fastlane_beta macos_fastlane_export
 
 .PHONY: macos_export
 macos_export: macos_build macos_fastlane_export

--- a/lotti/lib/pages/create/create_text_entry_page.dart
+++ b/lotti/lib/pages/create/create_text_entry_page.dart
@@ -54,6 +54,7 @@ class _CreateTextEntryPageState extends State<CreateTextEntryPage> {
             focusNode: _focusNode,
             saveFn: _save,
             minHeight: 200,
+            autoFocus: true,
           ),
         ),
       ),

--- a/lotti/lib/widgets/journal/editor/editor_widget.dart
+++ b/lotti/lib/widgets/journal/editor/editor_widget.dart
@@ -22,7 +22,7 @@ class EditorWidget extends StatelessWidget {
     this.minHeight = 40,
     this.maxHeight = double.maxFinite,
     this.padding = 16.0,
-    this.autoFocus = true,
+    this.autoFocus = false,
     required this.saveFn,
     required this.focusNode,
   }) : super(key: key);

--- a/lotti/lib/widgets/tasks/task_form.dart
+++ b/lotti/lib/widgets/tasks/task_form.dart
@@ -162,7 +162,8 @@ class _TaskFormState extends State<TaskForm> {
                   selectedColor: widget.data?.status != null
                       ? taskColor(widget.data!.status)
                       : AppColors.entryBgColor,
-                  runSpacing: 0,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  runSpacing: 6,
                   spacing: 4,
                   labelStyle: const TextStyle(
                     fontSize: 12,

--- a/lotti/pubspec.yaml
+++ b/lotti/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.15+751
+version: 0.7.16+752
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR changes the text editor autofocus default to false for improved scrolling in tasks.